### PR TITLE
Show full path of recent files in a tooltip

### DIFF
--- a/glogg.pro
+++ b/glogg.pro
@@ -34,6 +34,7 @@ SOURCES += main.cpp \
     quickfindwidget.cpp \
     sessioninfo.cpp \
     recentfiles.cpp \
+    menuactiontooltipbehavior.cpp \
     overview.cpp \
     overviewwidget.cpp \
     marks.cpp
@@ -65,6 +66,7 @@ HEADERS += \
     sessioninfo.h \
     persistable.h \
     recentfiles.h \
+    menuactiontooltipbehavior.h \
     overview.h \
     overviewwidget.h \
     marks.h

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -35,6 +35,7 @@
 #include "optionsdialog.h"
 #include "persistentinfo.h"
 #include "savedsearches.h"
+#include "menuactiontooltipbehavior.h"
 
 MainWindow::MainWindow() :
     recentFiles( Persistent<RecentFiles>( "recentFiles" ) ), mainIcon_()
@@ -187,8 +188,11 @@ void MainWindow::createMenus()
     fileMenu = menuBar()->addMenu( tr("&File") );
     fileMenu->addAction( openAction );
     fileMenu->addSeparator();
-    for (int i = 0; i < MaxRecentFiles; ++i)
+    for (int i = 0; i < MaxRecentFiles; ++i) {
         fileMenu->addAction( recentFileActions[i] );
+        recentFileActionBehaviors[i] =
+            new MenuActionToolTipBehavior(recentFileActions[i], fileMenu, this);
+    }
     fileMenu->addSeparator();
     fileMenu->addAction( exitAction );
 
@@ -500,6 +504,7 @@ void MainWindow::updateRecentFileActions()
         if ( j < recent_files.count() ) {
             QString text = tr("&%1 %2").arg(j + 1).arg(strippedName(recent_files[j]));
             recentFileActions[j]->setText( text );
+            recentFileActions[j]->setToolTip( recent_files[j] );
             recentFileActions[j]->setData( recent_files[j] );
             recentFileActions[j]->setVisible( true );
         }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -26,6 +26,7 @@
 
 class QAction;
 class RecentFiles;
+class MenuActionToolTipBehavior;
 
 // Main window of the application, creates menus, toolbar and
 // the CrawlerWidget
@@ -87,6 +88,7 @@ class MainWindow : public QMainWindow
     void createToolBars();
     void createStatusBar();
     void createCrawler();
+    void createRecentFileToolTipTimer();
     void readSettings();
     void writeSettings();
     bool loadFile( const QString& fileName );
@@ -105,6 +107,7 @@ class MainWindow : public QMainWindow
 
     enum { MaxRecentFiles = 5 };
     QAction *recentFileActions[MaxRecentFiles];
+    MenuActionToolTipBehavior *recentFileActionBehaviors[MaxRecentFiles];
     QAction *separatorAction;
 
     QMenu *fileMenu;

--- a/menuactiontooltipbehavior.cpp
+++ b/menuactiontooltipbehavior.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2009, 2010 Nicolas Bonnefon and other contributors
+ *
+ * This file is part of glogg.
+ *
+ * glogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * glogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with glogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <QAction>
+#include <QMenu>
+#include <QTimerEvent>
+#include <QToolTip>
+
+#include "menuactiontooltipbehavior.h"
+
+// It would be nice to only need action, and have action be the parent,
+// however implementation needs the parent menu (see showToolTip), and
+// since neither action nor parent is guaranteed to die before the other,
+// for memory-management purposes the parent will have to be specified
+// explicity (probably, the window owning the action and the menu).
+MenuActionToolTipBehavior::MenuActionToolTipBehavior(QAction *action,
+                                                     QMenu *parentMenu,
+                                                     QObject *parent = 0)
+    : QObject(parent),
+      action(action),
+      parentMenu(parentMenu),
+      toolTipDelayMs(1000),
+      timerId(0),
+      hoverPoint()
+{
+    connect(action, SIGNAL(hovered()), this, SLOT(onActionHovered()));
+}
+
+int MenuActionToolTipBehavior::toolTipDelay()
+{
+    return toolTipDelayMs;
+}
+
+void MenuActionToolTipBehavior::setToolTipDelay(int delayMs)
+{
+    toolTipDelayMs = delayMs;
+}
+
+void MenuActionToolTipBehavior::timerEvent(QTimerEvent *event)
+{
+    // Not ours, don't touch
+    if (event->timerId() != timerId) {
+        QObject::timerEvent(event);
+        return;
+    }
+
+    killTimer(timerId); // interested in a single shot
+    timerId = 0;
+
+    // Has the mouse waited unmoved in one location for 'delay' ms?
+    const QPoint &mousePos = QCursor::pos();
+    if (hoverPoint == mousePos)
+        showToolTip(hoverPoint);
+}
+
+void MenuActionToolTipBehavior::onActionHovered()
+{
+    const QPoint &mousePos = QCursor::pos();
+
+    // Hover is fired on keyboard focus over action in menu, ignore it
+    const QPoint &relativeMousePos = parentMenu->mapFromGlobal(mousePos);
+    if (!parentMenu->actionGeometry(action).contains(relativeMousePos)) {
+        if (timerId != 0) { // once timer expires its check will fail anyway
+            killTimer(timerId);
+            timerId = 0;
+        }
+        QToolTip::hideText(); // there might be one currently shown
+        return;
+    }
+
+    // Record location
+    hoverPoint = mousePos;
+
+    // Restart timer
+    if (timerId != 0)
+        killTimer(timerId);
+    timerId = startTimer(toolTipDelayMs);
+}
+
+void MenuActionToolTipBehavior::showToolTip(const QPoint &position)
+{
+    const QString &toolTip = action->toolTip();
+    // Show tooltip until mouse moves at all
+    // NOTE: using action->parentWidget() which is the MainWindow,
+    // does not work (tooltip is not cleared when upon leaving the
+    // region). This is the only reason we need parentMenu here. Just
+    // a wild guess: maybe it isn't cleared because it would be
+    // cleared on a mouse move over the designated widget, but mouse
+    // move doesn't happen over MainWindow, since the mouse is over
+    // the menu even when out of the activeRegion.
+    QPoint relativePos = parentMenu->mapFromGlobal(position);
+    QRect activeRegion(relativePos.x(), relativePos.y(), 1, 1);
+    QToolTip::showText(position, toolTip, parentMenu, activeRegion);
+}

--- a/menuactiontooltipbehavior.h
+++ b/menuactiontooltipbehavior.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2009, 2010 Nicolas Bonnefon and other contributors
+ *
+ * This file is part of glogg.
+ *
+ * glogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * glogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with glogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MANUACTIONTOOLTIPBEHAVIOR_H
+#define MANUACTIONTOOLTIPBEHAVIOR_H
+
+#include <QObject>
+#include <QPoint>
+
+class QAction;
+class QMenu;
+class QTimerEvent;
+
+
+// Provides a behavior to show an action's tooltip after mouse is unmoved for
+// a specified number of 'ms'. E.g. used for tooltips with full-path for recent
+// files in the file menu. Not thread-safe.
+class MenuActionToolTipBehavior : public QObject
+{
+    Q_OBJECT;
+
+ public:
+    MenuActionToolTipBehavior(QAction *action, QMenu *parentMenu,
+                              QObject *parent);
+
+    // Time in ms that mouse needs to stay unmoved for tooltip to be shown
+    int toolTipDelay(); /* ms */
+    void setToolTipDelay(int ms);
+
+ private:
+    void timerEvent(QTimerEvent *event);
+    void showToolTip(const QPoint &position);
+
+ private slots:
+    void onActionHovered();
+
+ private:
+    QAction *action;
+    QMenu *parentMenu;
+    int toolTipDelayMs;
+    int timerId;
+    QPoint hoverPoint;
+};
+
+#endif


### PR DESCRIPTION
Motivation: I often view multiple log files with the same name from different paths (they come from different users, e.g.). This makes the recent files list in the files menu be useful in this use-case.
