### PR TITLE
No monospace fonts, highlight partially visible matches, line wrap

### DIFF
--- a/abstractlogview.cpp
+++ b/abstractlogview.cpp
@@ -33,6 +33,7 @@
 #include <QPainter>
 #include <QFontMetrics>
 #include <QScrollBar>
+#include <QtCore/qmath.h>
 
 #include "log.h"
 
@@ -81,6 +82,11 @@ QList<LineChunk> LineChunk::select( int sel_start, int sel_end ) const
     return list;
 }
 
+inline void LineDrawer::setWrapLines( bool wrapLines )
+{
+    wrapLines_ = wrapLines;
+}
+
 inline void LineDrawer::addChunk( int first_col, int last_col,
         QColor fore, QColor back )
 {
@@ -102,30 +108,70 @@ inline void LineDrawer::addChunk( const LineChunk& chunk,
 }
 
 inline void LineDrawer::draw( QPainter& painter,
-        int xPos, int yPos, int line_width, const QString& line )
+                              int xPos, int yPos,
+                              int line_width, int nbCols,
+                              const QString& line )
 {
     QFontMetrics fm = painter.fontMetrics();
     const int fontHeight = fm.height();
     const int fontWidth = fm.maxWidth();
     const int fontAscent = fm.ascent();
 
+    int yPosFrag = yPos;
+    int xPosFrag = xPos;
+    int nbFreeCols = nbCols;
+
     foreach ( Chunk chunk, list ) {
         // Draw each chunk
-        // LOG(logDEBUG) << "Chunk: " << chunk.start() << " " << chunk.length();
-        QString cutline = line.mid( chunk.start(), chunk.length() );
-        const int chunk_width = cutline.length() * fontWidth;
-        painter.fillRect( xPos, yPos, chunk_width,
-                fontHeight, chunk.backColor() );
-        painter.setPen( chunk.foreColor() );
-        painter.drawText( xPos, yPos + fontAscent, cutline );
-        xPos += chunk_width;
+        LOG(logDEBUG4) << "Chunk: " << chunk.start() << " " << chunk.length();
+        // Break down chunk into "fragments", where each fragment
+        // is the maximum piece that stays within the same
+        // visible line (ie. doesn't wrap)
+        int chunkCharsDrawn = 0;
+        int fragsDrawn = 0;
+        int fragWidth;
+        // When wrapping: draw entire chunk,
+        // when not wrapping: draw just the first fragment
+        while ( (wrapLines_ && chunkCharsDrawn < chunk.length() ) ||
+               ( ! wrapLines_ && fragsDrawn <= 0 ) ) {
+            // Fragment restricted by either how much we need to draw or
+            // how much space we have available
+            int fragLength = qMin( chunk.length() - chunkCharsDrawn,
+                                   nbFreeCols );
+            QString fragment = line.mid( chunk.start() + chunkCharsDrawn,
+                                         fragLength );
+            LOG(logDEBUG4) << "  Fragment (" << fragLength << "): "
+                           << "'" << fragment.toStdString() << "'";
+            fragWidth = fragLength * fontWidth;
+            painter.fillRect( xPosFrag, yPosFrag, fragWidth,
+                              fontHeight, chunk.backColor() );
+            painter.setPen( chunk.foreColor() );
+            painter.drawText( xPosFrag, yPosFrag + fontAscent, fragment );
+            if ( wrapLines_ &&
+                 fragLength < chunk.length() - chunkCharsDrawn ) { // wrapped
+                LOG(logDEBUG4) << "  Line wrapped";
+                // Draw the empty block at the end of the line
+                int blank_width = line_width - (xPosFrag + fragWidth);
+                if ( blank_width > 0 )
+                    painter.fillRect( xPosFrag + fragWidth, yPosFrag, blank_width,
+                                      fontHeight, backColor_ );
+                yPosFrag += fontHeight;
+                xPosFrag = xPos; // "carriage-return"
+                nbFreeCols = nbCols;
+            } else {
+                xPosFrag += fragWidth;
+                nbFreeCols -= fragLength;
+            }
+            chunkCharsDrawn += fragLength;
+            ++fragsDrawn;
+        }
     }
 
     // Draw the empty block at the end of the line
-    int blank_width = line_width - xPos;
+    int blank_width = line_width - xPosFrag;
 
     if ( blank_width > 0 )
-        painter.fillRect( xPos, yPos, blank_width, fontHeight, backColor_ );
+        painter.fillRect( xPosFrag, yPosFrag, blank_width, fontHeight, backColor_ );
 }
 
 const int DigitsBuffer::timeout_ = 2000;
@@ -183,6 +229,7 @@ AbstractLogView::AbstractLogView(const AbstractLogData* newLogData,
     selectionCurrentEndPos_(),
     autoScrollTimer_(),
     selection_(),
+    visibleLineToFilePos(),
     quickFindPattern_( quickFindPattern ),
     quickFind_( newLogData, &selection_, quickFindPattern ),
     overviewWidget_( this )
@@ -190,12 +237,12 @@ AbstractLogView::AbstractLogView(const AbstractLogData* newLogData,
     logData = newLogData;
 
     followMode_ = false;
+    wrapLines_ = false;
 
     selectionStarted_ = false;
     markingClickInitiated_ = false;
 
     firstLine = 0;
-    lastLine = 0;
     firstCol = 0;
 
     overview_ = NULL;
@@ -508,11 +555,6 @@ void AbstractLogView::scrollContentsBy( int dx, int dy )
 
     firstLine = (firstLine - dy) > 0 ? firstLine - dy : 0;
     firstCol  = (firstCol - dx) > 0 ? firstCol - dx : 0;
-    lastLine = qMin( logData->getNbLine(), firstLine + getNbVisibleLines() );
-
-    // Update the overview if we have one
-    if ( overview_ != NULL )
-        overview_->updateCurrentPosition( firstLine, lastLine );
 
     // Redraw
     update();
@@ -524,8 +566,7 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
     if ( (invalidRect.isEmpty()) || (logData == NULL) )
         return;
 
-    LOG(logDEBUG4) << "paintEvent received, firstLine=" << firstLine
-        << " lastLine=" << lastLine <<
+    LOG(logDEBUG4) << "paintEvent received, firstLine=" << firstLine <<
         " rect: " << invalidRect.topLeft().x() <<
         ", " << invalidRect.topLeft().y() <<
         ", " << invalidRect.bottomRight().x() <<
@@ -554,12 +595,7 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
         else {
             if ( firstLine >= nbLines )
                 firstLine = nbLines - 1;
-            if ( lastLine >= nbLines )
-                lastLine =  nbLines - 1;
         }
-
-        // Lines to write
-        const QStringList lines = logData->getExpandedLines( firstLine, lastLine - firstLine + 1 );
 
         // First draw the bullet left margin
         painter.setPen(palette.color(QPalette::Text));
@@ -567,23 +603,34 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
         painter.fillRect( 0, 0, bulletLineX_, viewport()->height(), Qt::darkGray );
 
         // Then draw each line
-        for (int i = firstLine; i <= lastLine; i++) {
-            // Position in pixel of the base line of the line to print
-            const int yPos = (i-firstLine) * fontHeight;
-            const int xPos = bulletLineX_ + 2;
+        const int xPos = bulletLineX_ + 2;
+        int yPos = 0;
+        qint64 nbDataLines = logData->getNbLine();
+        int nbVisibleLines = getNbVisibleLines();
+        int dataLine = firstLine;
+        int visibleLine = 0;
+        visibleLineToFilePos.resize( nbVisibleLines );
 
-            // string to print, cut to fit the length and position of the view
-            const QString line = lines[i - firstLine];
-            const QString cutLine = line.mid( firstCol, nbCols );
+        while ( visibleLine < nbVisibleLines && dataLine < nbDataLines ) {
+            // The characters of the whole line that is being printed
+            const QString& line = logData->getExpandedLineString(dataLine);
 
-            if ( selection_.isLineSelected( i ) ) {
+            int lineLen, startColumn;
+            if ( wrapLines_ ) {
+                lineLen = line.length();
+                startColumn = 0;
+            } else {
+                lineLen = qMin( line.length() - firstCol, nbCols );
+                startColumn = firstCol;
+            }
+
+            if ( selection_.isLineSelected( dataLine ) ) {
                 // Reverse the selected line
                 foreColor = palette.color( QPalette::HighlightedText );
                 backColor = palette.color( QPalette::Highlight );
                 painter.setPen(palette.color(QPalette::Text));
             }
-            else if ( filterSet.matchLine( logData->getLineString( i ),
-                        &foreColor, &backColor ) ) {
+            else if ( filterSet.matchLine( line, &foreColor, &backColor ) ) {
                 // Apply a filter to the line
             }
             else {
@@ -594,17 +641,20 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
 
             // Is there something selected in the line?
             int sel_start, sel_end;
+
             bool isSelection =
-                selection_.getPortionForLine( i, &sel_start, &sel_end );
+                selection_.getPortionForLine( dataLine, &sel_start, &sel_end );
             // Has the line got elements to be highlighted
             QList<QuickFindMatch> qfMatchList;
             bool isMatch =
                 quickFindPattern_->matchLine( line, qfMatchList );
 
+            int dyPos = 0; // change in yPos after drawing all fragments
             if ( isSelection || isMatch ) {
                 // We use the LineDrawer and its chunks because the
                 // line has to be somehow highlighted
                 LineDrawer lineDrawer( backColor );
+                lineDrawer.setWrapLines( wrapLines_ );
 
                 // First we create a list of chunks with the highlights
                 QList<LineChunk> chunkList;
@@ -617,13 +667,14 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
                         continue;
                     if ( start > column )
                         chunkList << LineChunk( column, start - 1, LineChunk::Normal );
-                    column = qMin( start + match.length() - 1, nbCols );
+                    column = qMin( start + match.length() - 1,
+                                   qMin( lineLen, nbCols ) );
                     chunkList << LineChunk( qMax( start, 0 ), column,
                                             LineChunk::Highlighted );
                     column++;
                 }
-                if ( column <= cutLine.length() - 1 )
-                    chunkList << LineChunk( column, cutLine.length() - 1, LineChunk::Normal );
+                if ( column <= lineLen - 1 )
+                    chunkList << LineChunk( column, lineLen - 1, LineChunk::Normal );
 
                 // Then we add the selection if needed
                 QList<LineChunk> newChunkList;
@@ -661,15 +712,32 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
                     lineDrawer.addChunk ( chunk, fore, back );
                 }
 
-                lineDrawer.draw( painter, xPos, yPos,
-                        viewport()->width(), cutLine );
+                if ( wrapLines_ ) {
+                    lineDrawer.draw( painter, xPos, yPos, viewport()->width(), nbCols, line );
+                } else {
+                    const QString& cutLine = line.mid( firstCol, nbCols );
+                    lineDrawer.draw( painter, xPos, yPos, viewport()->width(), nbCols, cutLine );
+                }
+                for ( int dataColumn = startColumn; dataColumn < lineLen; dataColumn += nbCols ) {
+                    dyPos += fontHeight;
+                    visibleLineToFilePos[visibleLine++] = QPoint( dataColumn, dataLine );
+                }
             }
             else {
                 // Nothing to be highlighted, we print the whole line!
-                painter.fillRect( xPos, yPos, viewport()->width(),
-                        fontHeight, backColor );
+                int nbFrags = qCeil( static_cast<double>(lineLen) / nbCols );
+                painter.fillRect( xPos, yPos + dyPos, viewport()->width(),
+                                  fontHeight * nbFrags, backColor );
                 painter.setPen( foreColor );
-                painter.drawText( xPos, yPos + fontAscent, cutLine );
+
+                // Draw wrapping if necessary
+                LOG(logDEBUG4) << "lineLen: " << lineLen << " nbCols: " << nbCols;
+                for ( int dataColumn = startColumn; dataColumn < lineLen; dataColumn += nbCols ) {
+                    painter.drawText( xPos, yPos + dyPos + fontAscent,
+                                      line.mid( dataColumn, nbCols ) );
+                    dyPos += fontHeight;
+                    visibleLineToFilePos[visibleLine++] = QPoint( dataColumn, dataLine );
+                }
             }
 
             // Then draw the bullet
@@ -679,7 +747,7 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
             const int middleXLine = bulletLineX_ / 2;
             const int middleYLine = yPos + (fontHeight / 2);
 
-            const LineType line_type = lineType( i );
+            const LineType line_type = lineType( dataLine );
             if ( line_type == Marked ) {
                 // A pretty arrow if the line is marked
                 const QPoint points[7] = {
@@ -696,7 +764,7 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
                 painter.drawPolygon( points, 7 );
             }
             else {
-                if ( lineType( i ) == Match )
+                if ( lineType( dataLine ) == Match )
                     painter.setBrush( matchBulletBrush );
                 else
                     painter.setBrush( normalBulletBrush );
@@ -704,7 +772,16 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
                         middleYLine - circleSize,
                         circleSize * 2, circleSize * 2 );
             }
+
+            ++dataLine;
+            yPos += dyPos;
         } // For each line
+
+        // Update the overview if we have one
+        if ( overview_ != NULL ) {
+            overview_->updateCurrentPosition( firstLine, dataLine );
+            overviewWidget_.update();
+        }
     }
     LOG(logDEBUG4) << "End of repaint";
 }
@@ -770,6 +847,12 @@ void AbstractLogView::refreshOverview()
     }
 }
 
+void AbstractLogView::setWrapLines( bool wrapLines )
+{
+    wrapLines_ = wrapLines;
+    update();
+}
+
 // Reset the QuickFind when the pattern is changed.
 void AbstractLogView::handlePatternUpdated()
 {
@@ -800,21 +883,21 @@ void AbstractLogView::updateData()
 
     // Adapt the scroll bars to the new content
     verticalScrollBar()->setRange( 0, logData->getNbLine()-1 );
-    const int hScrollMaxValue = ( logData->getMaxLength() - getNbVisibleCols() + 1 ) > 0 ?
-        ( logData->getMaxLength() - getNbVisibleCols() + 1 ) : 0;
-    horizontalScrollBar()->setRange( 0, hScrollMaxValue );
 
-    lastLine = qMin( logData->getNbLine(), firstLine + getNbVisibleLines() );
+    // Disable horizontal scroll bar when wrapping is turned on
+    int hScrollMaxValue = 0;
+    if ( ! wrapLines_ ) {
+        hScrollMaxValue =
+            ( logData->getMaxLength() - getNbVisibleCols() + 1 ) > 0 ?
+                ( logData->getMaxLength() - getNbVisibleCols() + 1 ) : 0;
+    }
+    horizontalScrollBar()->setRange( 0, hScrollMaxValue );
 
     // Reset the QuickFind in case we have new stuff to search into
     quickFind_.resetLimits();
 
     if ( followMode_ )
         jumpToBottom();
-
-    // Update the overview if we have one
-    if ( overview_ != NULL )
-        overview_->updateCurrentPosition( firstLine, lastLine );
 
     // Repaint!
     update();
@@ -827,20 +910,22 @@ void AbstractLogView::updateDisplaySize()
     charHeight_ = fm.height();
     charWidth_ = fm.maxWidth();
 
-    // Calculate the index of the last line shown
-    lastLine = qMin( logData->getNbLine(), firstLine + getNbVisibleLines() );
-
     // Update the scroll bars
     verticalScrollBar()->setPageStep( getNbVisibleLines() );
 
-    const int hScrollMaxValue = ( logData->getMaxLength() - getNbVisibleCols() + 1 ) > 0 ?
-        ( logData->getMaxLength() - getNbVisibleCols() + 1 ) : 0;
-    horizontalScrollBar()->setRange( 0, hScrollMaxValue );
+    int hScrollMaxValue = 0;
+    if ( ! wrapLines_ ) {
+        hScrollMaxValue =
+            ( logData->getMaxLength() - getNbVisibleCols() + 1 ) > 0 ?
+                ( logData->getMaxLength() - getNbVisibleCols() + 1 ) : 0;
+    }
+    horizontalScrollBar()->setRange( 0,  hScrollMaxValue );
 
     LOG(logDEBUG) << "viewport.width()=" << viewport()->width();
     LOG(logDEBUG) << "viewport.height()=" << viewport()->height();
     LOG(logDEBUG) << "width()=" << width();
     LOG(logDEBUG) << "height()=" << height();
+    LOG(logDEBUG) << "hScrollMaxValue=" << hScrollMaxValue;
     overviewWidget_.setGeometry( viewport()->width() + 2, 1,
             OVERVIEW_WIDTH - 1, viewport()->height() );
 }
@@ -889,44 +974,58 @@ int AbstractLogView::getNbVisibleLines() const
 // Returns the number of columns visible in the viewport
 int AbstractLogView::getNbVisibleCols() const
 {
-    return ( viewport()->width() - leftMarginPx_ ) / charWidth_ + 1;
+    int pixelWidth = viewport()->width() - leftMarginPx_ -
+        verticalScrollBar()->width();
+    return pixelWidth / charWidth_ + 1;
 }
 
 // Converts the mouse x, y coordinates to the line number in the file
 int AbstractLogView::convertCoordToLine(int yPos) const
 {
-    QFontMetrics fm = fontMetrics();
-    int line = firstLine + yPos/fm.height();
+    int visibleLine = yPos / charHeight_;
+    const QPoint& lineStartFilePos = visibleLineToFilePos[visibleLine];
 
-    return line;
+    LOG(logDEBUG) << "AbstractLogView::convertCoordToLine "
+        << "view y pos " << yPos << " -> file line " << lineStartFilePos.y();
+    return lineStartFilePos.y();
 }
 
 // Converts the mouse x, y coordinates to the char coordinates (in the file)
 // This function ensure the pos exists in the file.
 QPoint AbstractLogView::convertCoordToFilePos( const QPoint& pos ) const
 {
-    int line = firstLine + pos.y() / charHeight_;
+    // Restrict mouse pos to the actual view region and normalize
+    int xPos = qMin( qMax( pos.x() - leftMarginPx_, 0 ),
+                     viewport()->width() - verticalScrollBar()->width() - leftMarginPx_ );
+    int yPos = pos.y();
+
+    int visibleLine = yPos / charHeight_;
+    int visibleColumn = xPos / charWidth_;
+    const QPoint& lineStartFilePos = visibleLineToFilePos[visibleLine];
+    int column = visibleColumn + lineStartFilePos.x();
+    int line = lineStartFilePos.y();
+
+    // Safety checks and bounds
+
+    QString this_line = logData->getExpandedLineString( line );
+    const int length = this_line.length();
+
     if ( line >= logData->getNbLine() )
         line = logData->getNbLine() - 1;
     if ( line < 0 )
         line = 0;
-
-    // Determine column in screen space and convert it to file space
-    int column = firstCol + ( pos.x() - leftMarginPx_ ) / charWidth_;
-
-    QString this_line = logData->getExpandedLineString( line );
-    const int length = this_line.length();
 
     if ( column >= length )
         column = length - 1;
     if ( column < 0 )
         column = 0;
 
-    LOG(logDEBUG) << "AbstractLogView::convertCoordToFilePos col="
-        << column << " line=" << line;
-    QPoint point( column, line );
+    QPoint filePos( column, line );
 
-    return point;
+    LOG(logDEBUG) << "AbstractLogView::convertCoordToFilePos "
+        << "view pos ( " << pos.x() << ", " << pos.y() << " ) -> "
+        << "file pos ( " << filePos.x() << ", " << filePos.y() << " )";
+    return filePos;
 }
 
 // Makes the widget adjust itself to display the passed line.

--- a/abstractlogview.cpp
+++ b/abstractlogview.cpp
@@ -978,8 +978,7 @@ int AbstractLogView::getNbVisibleLines() const
 // Returns the number of columns visible in the viewport
 int AbstractLogView::getNbVisibleCols() const
 {
-    int pixelWidth = viewport()->width() - leftMarginPx_ -
-        verticalScrollBar()->width();
+    int pixelWidth = viewport()->width() - leftMarginPx_;
     return pixelWidth / charWidth_ + 1;
 }
 

--- a/abstractlogview.cpp
+++ b/abstractlogview.cpp
@@ -577,7 +577,7 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
         QPainter painter( viewport() );
         const int fontHeight = painter.fontMetrics().height();
         const int fontAscent = painter.fontMetrics().ascent();
-        const int nbCols = getNbVisibleCols();
+        const int nbCols = wrapLines_ ? getNbFullyVisibleCols() : getNbVisibleCols();
         const QPalette& palette = viewport()->palette();
         const FilterSet& filterSet = Persistent<FilterSet>( "filterSet" );
         QColor foreColor, backColor;
@@ -980,6 +980,12 @@ int AbstractLogView::getNbVisibleCols() const
 {
     int pixelWidth = viewport()->width() - leftMarginPx_;
     return pixelWidth / charWidth_ + 1;
+}
+
+int AbstractLogView::getNbFullyVisibleCols() const
+{
+    int pixelWidth = viewport()->width() - leftMarginPx_;
+    return pixelWidth / charWidth_;
 }
 
 // Converts the mouse x, y coordinates to the line number in the file

--- a/abstractlogview.cpp
+++ b/abstractlogview.cpp
@@ -723,7 +723,9 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
                     dyPos += fontHeight;
                     visibleLineToFilePos[visibleLine++] = QPoint( dataColumn, dataLine );
                     dataColumn += nbCols;
-                } while (dataColumn - startColumn < lineLen || nbCols == 0);
+                } while ( ( dataColumn - startColumn < lineLen &&
+                            visibleLine < nbVisibleLines ) ||
+                           nbCols == 0 );
             }
             else {
                 // Nothing to be highlighted, we print the whole line!
@@ -741,7 +743,9 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
                     dyPos += fontHeight;
                     visibleLineToFilePos[visibleLine++] = QPoint( dataColumn, dataLine );
                     dataColumn += nbCols;
-                } while (dataColumn - startColumn < lineLen || nbCols == 0);
+                } while ( ( dataColumn - startColumn < lineLen &&
+                            visibleLine < nbVisibleLines ) ||
+                           nbCols == 0 );
             }
 
             // Then draw the bullet

--- a/abstractlogview.h
+++ b/abstractlogview.h
@@ -284,6 +284,7 @@ class AbstractLogView : public QAbstractScrollArea
 
     int getNbVisibleLines() const;
     int getNbVisibleCols() const;
+    int getNbFullyVisibleCols() const;
     void convertCoordToFilePos( const QPoint& pos,
             int* line, int* column ) const;
     QPoint convertCoordToFilePos( const QPoint& pos ) const;

--- a/abstractlogview.h
+++ b/abstractlogview.h
@@ -60,7 +60,12 @@ class LineDrawer
 {
   public:
     LineDrawer( const QColor& back_color) :
-        list(), backColor_( back_color ) { };
+        list(),
+        backColor_( back_color ),
+        wrapLines_( false )
+    { };
+
+    void setWrapLines( bool wrapLines );
 
     // Add a chunk of line using the given colours.
     // Both first_col and last_col are included
@@ -70,11 +75,13 @@ class LineDrawer
     void addChunk( int first_col, int last_col, QColor fore, QColor back );
     void addChunk( const LineChunk& chunk, QColor fore, QColor back );
 
-    // Draw the current line of text using the given painter,
-    // in the passed block (in pixels)
-    // The line must be cut to fit on the screen.
+    // Draw the current line of text using the given painter, in the
+    // passed block, wrapping as necessary. Block is restricted only
+    // in x-axis, the wrapping can occupy any number of lines in the
+    // y-direction.  Width of block is passed in pixels (line_width)
+    // and in chars (nbCols).
     void draw( QPainter& painter, int xPos, int yPos,
-            int line_width, const QString& line );
+               int line_width, int nbCols, const QString& line );
 
   private:
     class Chunk {
@@ -98,6 +105,7 @@ class LineDrawer
     };
     QList<Chunk> list;
     QColor backColor_;
+    bool wrapLines_;
 };
 
 
@@ -217,6 +225,9 @@ class AbstractLogView : public QAbstractScrollArea
     // (does NOT emit followDisabled() )
     void jumpToLine( int line );
 
+    // Set the flag that controls line wrapping
+    void setWrapLines( bool wrapLines );
+
   private slots:
     void handlePatternUpdated();
 
@@ -231,6 +242,8 @@ class AbstractLogView : public QAbstractScrollArea
 
     // Follow mode
     bool followMode_;
+
+    bool wrapLines_;
 
     // Pointer to the CrawlerWidget's data set
     const AbstractLogData* logData;
@@ -251,13 +264,16 @@ class AbstractLogView : public QAbstractScrollArea
 
     Selection selection_;
     qint64 firstLine;
-    qint64 lastLine;
     int firstCol;
 
     // Text handling
     bool useFixedFont_;
     int charWidth_;             // Must only be used if useFixedFont_ == true
     int charHeight_;
+
+    // Map: visible line number -> file (column, line) where visible text starts
+    // For converting coord to data line
+    QVector<QPoint> visibleLineToFilePos;
 
     // Pointer to the CrawlerWidget's QFP object
     const QuickFindPattern* const quickFindPattern_;

--- a/configuration.cpp
+++ b/configuration.cpp
@@ -36,6 +36,8 @@ Configuration::Configuration()
 
     QFontInfo fi(mainFont_);
     LOG(logDEBUG) << "Default font is " << fi.family().toStdString();
+
+    wrapLines_ = false;
 }
 
 // Accessor functions
@@ -72,6 +74,8 @@ void Configuration::retrieveFromStorage( QSettings& settings )
     // View settings
     if ( settings.contains( "view.overviewVisible" ) )
         overviewVisible_ = settings.value( "view.overviewVisible" ).toBool();
+    if ( settings.contains( "view.wrapLines" ) )
+        wrapLines_ = settings.value( "view.wrapLines" ).toBool();
 }
 
 void Configuration::saveToStorage( QSettings& settings ) const
@@ -85,4 +89,5 @@ void Configuration::saveToStorage( QSettings& settings ) const
     settings.setValue( "regexpType.main", static_cast<int>( mainRegexpType_ ) );
     settings.setValue( "regexpType.quickfind", static_cast<int>( quickfindRegexpType_ ) );
     settings.setValue( "view.overviewVisible", overviewVisible_ );
+    settings.setValue( "view.wrapLines", wrapLines_ );
 }

--- a/configuration.h
+++ b/configuration.h
@@ -57,6 +57,11 @@ class Configuration : public Persistable {
     void setOverviewVisible( bool isVisible )
     { overviewVisible_ = isVisible; }
 
+    bool wrapLines() const
+    { return wrapLines_; }
+    void setWrapLines( bool wrapLines )
+    { wrapLines_ = wrapLines; }
+
     // Reads/writes the current config in the QSettings object passed
     virtual void saveToStorage( QSettings& settings ) const;
     virtual void retrieveFromStorage( QSettings& settings );
@@ -69,6 +74,7 @@ class Configuration : public Persistable {
 
     // View settings
     bool overviewVisible_;
+    bool wrapLines_;
 };
 
 #endif

--- a/crawlerwidget.cpp
+++ b/crawlerwidget.cpp
@@ -385,11 +385,14 @@ void CrawlerWidget::applyConfiguration()
 {
     Configuration& config = Persistent<Configuration>( "settings" );
     QFont font = config.mainFont();
+    bool wrapLines = config.wrapLines();
 
     LOG(logDEBUG) << "CrawlerWidget::applyConfiguration";
 
     logMainView->setFont(font);
     filteredView->setFont(font);
+    logMainView->setWrapLines(wrapLines);
+    filteredView->setWrapLines(wrapLines);
 
     overview_->setVisible( config.isOverviewVisible() );
     logMainView->refreshOverview();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -150,6 +150,12 @@ void MainWindow::createActions()
     connect( overviewVisibleAction, SIGNAL( toggled( bool ) ),
             this, SLOT( toggleOverviewVisibility( bool )) );
 
+    wrapLinesAction = new QAction( tr("&Wrap lines"), this );
+    wrapLinesAction->setCheckable( true );
+    wrapLinesAction->setChecked( config.wrapLines() );
+    connect( wrapLinesAction, SIGNAL( toggled( bool ) ),
+            this, SLOT( toggleWrapLines( bool )) );
+
     followAction = new QAction( tr("&Follow File"), this );
     followAction->setShortcut(Qt::Key_F);
     followAction->setCheckable(true);
@@ -198,6 +204,7 @@ void MainWindow::createMenus()
 
     viewMenu = menuBar()->addMenu( tr("&View") );
     viewMenu->addAction( overviewVisibleAction );
+    viewMenu->addAction( wrapLinesAction );
     viewMenu->addSeparator();
     viewMenu->addAction( followAction );
     viewMenu->addSeparator();
@@ -335,6 +342,13 @@ void MainWindow::toggleOverviewVisibility( bool isVisible )
 
     config.setOverviewVisible( isVisible );
 
+    emit optionsChanged();
+}
+
+void MainWindow::toggleWrapLines( bool wrapLines )
+{
+    Configuration& config = Persistent<Configuration>( "settings" );
+    config.setWrapLines( wrapLines );
     emit optionsChanged();
 }
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -59,6 +59,7 @@ class MainWindow : public QMainWindow
 
     // Change the view settings
     void toggleOverviewVisibility( bool isVisible );
+    void toggleWrapLines( bool wrapLines );
 
     // Disable the follow mode checkbox and send the followSet signal down
     void disableFollow();
@@ -122,6 +123,7 @@ class MainWindow : public QMainWindow
     QAction *copyAction;
     QAction *findAction;
     QAction *overviewVisibleAction;
+    QAction *wrapLinesAction;
     QAction *followAction;
     QAction *reloadAction;
     QAction *stopAction;

--- a/optionsdialog.cpp
+++ b/optionsdialog.cpp
@@ -50,7 +50,11 @@ void OptionsDialog::setupFontList()
 {
     QFontDatabase database;
 
-    fontFamilyBox->addItems(database.families());
+    // We only show the fixed fonts
+    foreach ( const QString &str, database.families() ) {
+         if ( database.isFixedPitch( str ) )
+             fontFamilyBox->addItem( str );
+     }
 }
 
 // Populate the regexp ComboBoxes


### PR DESCRIPTION
Some notes about this far-from-ideal implementation of line wrapping:
- no longer track lastLine since no longer know how many lines fit in the view
  until we actually fetch and draw them; implications:
  - fetching lines from logData one by one
  - forcing an update to overviewWidget after AbstractLogView paints
- wrapping logic is in two places because drawing is in two places:
  LineDrawer::draw() (for lines drawn in chunks) and AbstractLogView::paint
  (for all other lines)
- convertCoordToLine: maintain the visibleLineToFilePos map for this

Instead of adding this wrapping logic to paint event (like I'm doing here), it
might be good to add state to AbstractLogView that is fully sufficient to draw:
state that would keep the data with the highlights, selections, wrapping points.
But since the less pretty approach in this patch is already done and is working,
I'm sending it out.

Also in this patch: getNbVisibleCols: subtract the width of vertical scroll bar
