### PR TITLE
Encoding patch from Stanislav Sikora with encoding selector in view menu

### DIFF
--- a/configuration.cpp
+++ b/configuration.cpp
@@ -18,9 +18,9 @@
  */
 
 #include <QFontInfo>
+#include <QTextCodec>
 
 #include "log.h"
-
 #include "configuration.h"
 
 Configuration::Configuration()
@@ -33,6 +33,7 @@ Configuration::Configuration()
     quickfindRegexpType_ = ExtendedRegexp;
 
     overviewVisible_     = true;
+    encoding_ = QTextCodec::codecForLocale()->name();
 
     QFontInfo fi(mainFont_);
     LOG(logDEBUG) << "Default font is " << fi.family().toStdString();
@@ -72,6 +73,12 @@ void Configuration::retrieveFromStorage( QSettings& settings )
     // View settings
     if ( settings.contains( "view.overviewVisible" ) )
         overviewVisible_ = settings.value( "view.overviewVisible" ).toBool();
+
+    if ( settings.contains( "view.encoding" ) ) {
+        const QString& encoding = settings.value( "view.encoding" ).toString();
+        if ( !encoding.isEmpty() )
+            encoding_ = encoding;
+    }
 }
 
 void Configuration::saveToStorage( QSettings& settings ) const
@@ -85,4 +92,5 @@ void Configuration::saveToStorage( QSettings& settings ) const
     settings.setValue( "regexpType.main", static_cast<int>( mainRegexpType_ ) );
     settings.setValue( "regexpType.quickfind", static_cast<int>( quickfindRegexpType_ ) );
     settings.setValue( "view.overviewVisible", overviewVisible_ );
+    settings.setValue( "view.encoding", encoding_ );
 }

--- a/configuration.h
+++ b/configuration.h
@@ -57,6 +57,11 @@ class Configuration : public Persistable {
     void setOverviewVisible( bool isVisible )
     { overviewVisible_ = isVisible; }
 
+    QString encoding() const
+    { return encoding_; }
+    void setEncoding( const QString& encoding )
+    { encoding_ = encoding; }
+
     // Reads/writes the current config in the QSettings object passed
     virtual void saveToStorage( QSettings& settings ) const;
     virtual void retrieveFromStorage( QSettings& settings );
@@ -69,6 +74,7 @@ class Configuration : public Persistable {
 
     // View settings
     bool overviewVisible_;
+    QString encoding_;
 };
 
 #endif

--- a/crawlerwidget.cpp
+++ b/crawlerwidget.cpp
@@ -33,6 +33,7 @@
 #include <QStandardItemModel>
 #include <QHeaderView>
 #include <QListView>
+#include <QTextCodec>
 
 #include "crawlerwidget.h"
 
@@ -56,6 +57,11 @@ CrawlerWidget::CrawlerWidget(SavedSearches* searches, QWidget *parent)
     // Initialise internal data (with empty file and search)
     logData_          = new LogData();
     logFilteredData_  = logData_->getNewFilteredData();
+
+    // Initialize to the default encoding from persisted options
+    Configuration& config = Persistent<Configuration>( "settings" );
+    const QString& encoding = config.encoding();
+    logData_->setCodec( QTextCodec::codecForName( encoding.toUtf8() ) );
 
     // Initialise the QFP object (one for both views)
     // This is the confirmed pattern used by n/N and coloured in yellow.
@@ -270,7 +276,8 @@ CrawlerWidget::CrawlerWidget(SavedSearches* searches, QWidget *parent)
 }
 
 // Start the asynchronous loading of a file.
-bool CrawlerWidget::readFile( const QString& fileName, int )
+bool CrawlerWidget::readFile( const QString& fileName, QTextCodec* codec,
+                              int )
 {
     QFileInfo fileInfo( fileName );
     if ( fileInfo.isReadable() )
@@ -284,6 +291,7 @@ bool CrawlerWidget::readFile( const QString& fileName, int )
         // and redraw the screen.
         replaceCurrentSearch( "" );
         logFilteredData_->clearMarks();
+        logData_->setCodec( codec );
         logData_->attachFile( fileName );
         logMainView->updateData();
 

--- a/crawlerwidget.h
+++ b/crawlerwidget.h
@@ -35,6 +35,8 @@
 #include "logdata.h"
 #include "logfiltereddata.h"
 
+class QTextCodec;
+
 class InfoLine;
 class QuickFindPattern;
 class QuickFindWidget;
@@ -53,7 +55,7 @@ class CrawlerWidget : public QSplitter
     CrawlerWidget( SavedSearches* searches, QWidget *parent=0 );
 
     // Loads the passed file and reports success.
-    bool readFile( const QString& fileName, int topLine );
+    bool readFile( const QString& fileName, QTextCodec* codec, int topLine );
     // Stop the loading of the file if one is in progress
     void stopLoading();
     // Get the size (in bytes) and number of lines in the current file.

--- a/encodingselector.cpp
+++ b/encodingselector.cpp
@@ -1,0 +1,331 @@
+/*
+ * Copyright (C) 2009, 2010, 2011 Nicolas Bonnefon and other contributors
+ *
+ * This file is part of glogg.
+ *
+ * glogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * glogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with glogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <QMenu>
+#include <QAction>
+#include <QActionGroup>
+#include <QTextCodec>
+#include <QStringList>
+
+#include "encodingselector.h"
+#include "configuration.h"
+#include "recentencodings.h"
+#include "persistentinfo.h"
+
+const QStringList& EncodingSelector::allEncodings()
+{
+    // Per-process lifetime
+    static QStringList encodings;
+    static bool initialized = false;
+
+    if ( ! initialized ) {
+        // Sort the available encodings using a map; display all aliases
+        QMap<QString, QString> encodingsMap; // toLower(encoding) -> encoding
+        foreach ( QByteArray encoding, QTextCodec::availableCodecs() ) {
+            QString encodingStr( encoding );
+            const QString& encodingStrLower = encodingStr.toLower();
+            encodingsMap.insert( encodingStrLower, encodingStr );
+        }
+        encodings = encodingsMap.values();
+        initialized = true;
+    }
+    return encodings;
+}
+
+EncodingSelector::EncodingSelector( Configuration* config,
+                                    RecentEncodings* recentEncodings,
+                                    QWidget* menuParent,
+                                    QObject* parent )
+    : QObject( parent )
+    , menuParent_( menuParent )
+    , config_( config )
+    , recentEncodings_( recentEncodings )
+    , actionGroup_( NULL )
+    , actions_()
+    , stickyActions_()
+    , recentActions_()
+    , defaultAction_( NULL )
+    , stickyAndDefaultSeparator_( NULL )
+    , recentSeparator_( NULL )
+{
+    createActions();
+    createMenu();
+}
+
+QMenu* EncodingSelector::encodingsMenu() const
+{
+    return encodingsMenu_;
+}
+
+QString EncodingSelector::selectedEncoding() const
+{
+    QAction* action = actionGroup_->checkedAction();
+    if ( action == NULL )
+        return QString();
+    return action->data().toString();
+}
+
+void EncodingSelector::applyConfiguration()
+{
+    changeDefaultEncoding();
+}
+
+void EncodingSelector::changeEncoding( QAction* action )
+{
+    makeRecent( action );
+    QString encoding = action->data().toString();
+    emit encodingChanged( encoding );
+}
+
+void EncodingSelector::createActions()
+{
+    const QStringList& encodings = EncodingSelector::allEncodings();
+
+    actionGroup_ = new QActionGroup( this );
+    connect( actionGroup_, SIGNAL( triggered( QAction* ) ),
+             this, SLOT( changeEncoding( QAction* ) ) );
+
+    foreach ( const QString& encoding, encodings ) {
+        QAction* action = new QAction( encoding, this );
+        action->setData( encoding ); // to not rely on display text
+        action->setCheckable( true );
+        action->setActionGroup( actionGroup_ );
+        if ( encoding == config_->encoding() )
+            action->setChecked( true );
+        actions_.insert( encoding, action );
+    }
+}
+
+void EncodingSelector::createMenu()
+{
+    // The encoding menu consists of foure parts:
+    //  (1) submenu with list of all available encodings
+    //  (2) section with "sticky" encodings:
+    //         system, utf8, and user-selected default
+    //  (3) item with the user-selected default encoding from options
+    //  (4) section with (persisted) recently-used encodings
+
+    encodingsMenu_ = new QMenu( tr("&Character Encoding"), menuParent_ );
+    createMoreEncodingsSection();
+    createStickySection();
+    createDefaultSection();
+    createRecentSection();
+}
+
+void EncodingSelector::createMoreEncodingsSection()
+{
+    moreEncodingsMenu_ = encodingsMenu_->addMenu( tr("&More encodings") );
+    const QStringList& encodings = EncodingSelector::allEncodings();
+    foreach ( const QString& encoding, encodings ) {
+        moreEncodingsMenu_->addAction( actions_[ encoding ] );
+    }
+}
+
+void EncodingSelector::createStickySection()
+{
+    // The sticky actions might coincide, and we must not add
+    // a sticky action more than once since that causes re-ordering,
+    // so we check membership before adding each one.
+
+    // Locale
+    QString localeEncoding = QTextCodec::codecForLocale()->name();
+    if ( actions_.contains( localeEncoding ) ) {
+        QAction* action = actions_[ localeEncoding ];
+        if ( ! stickyActions_.contains( action ) )
+            stickyActions_.append( action );
+    }
+
+    // UTF-8
+    const char utf8Encoding[] = "UTF-8";
+    if ( actions_.contains( utf8Encoding ) ) {
+        QAction* action = actions_[ utf8Encoding ];
+        if ( ! stickyActions_.contains( action ) )
+            stickyActions_.append( action );
+    }
+
+    // Push from model to view
+    if ( ! stickyActions_.empty() ) {
+        stickyAndDefaultSeparator_ = encodingsMenu_->addSeparator();
+        foreach ( QAction* action, stickyActions_ )
+            encodingsMenu_->addAction( action );
+    }
+}
+
+void EncodingSelector::createDefaultSection()
+{
+    // User-persisted default
+    if ( actions_.contains( config_->encoding() ) ) {
+        QAction* action = actions_[ config_->encoding() ];
+        if ( ! stickyActions_.contains( action ) )
+            defaultAction_ = action;
+    }
+
+    // Push from model to view
+    if ( defaultAction_ != NULL ) {
+        if ( stickyAndDefaultSeparator_ == NULL )
+            stickyAndDefaultSeparator_ = encodingsMenu_->addSeparator();
+        encodingsMenu_->addAction( defaultAction_ );
+    }
+}
+
+void EncodingSelector::createRecentSection()
+{
+    // Resolve encoding names into actions and add them to model
+    foreach ( QString encoding, recentEncodings_->recentEncodings() ) {
+        if (  actions_.contains( encoding )) {
+            QAction* action = actions_[ encoding ];
+            // Invariant: recentActions and {stickyActions,default} are disjoint
+            if ( ! stickyActions_.contains( action ) &&
+                 action != defaultAction_ ) {
+                recentActions_.append( action );
+            }
+        }
+    }
+
+    // Push from model to view
+    if ( ! recentActions_.empty() ) {
+        recentSeparator_ = encodingsMenu_->addSeparator();
+        foreach ( QAction* action, recentActions_ ) {
+            encodingsMenu_->addAction( action );
+        }
+    }
+}
+
+void EncodingSelector::changeDefaultEncoding()
+{
+    // This method updates the menu item corresponding to persisted
+    // user-selected default encoding. We assume that the default goes right
+    // before the recents separator.
+
+    // Get the new default
+    QAction* defaultAction = NULL;
+    if ( actions_.contains( config_->encoding() ) )
+        defaultAction = actions_[ config_->encoding() ];
+
+    // Check if there was any change at all
+    if ( defaultAction == defaultAction_ )
+        return;
+
+    // Update the model
+    QAction* oldDefaultAction = defaultAction_;
+    int defaultIndexInRecents = -1;
+    if ( defaultAction != NULL ) {
+        if ( ! stickyActions_.contains( defaultAction ) ) {
+            // Remove the new one in case it appears in recents
+            // Invariant: recentActions and {stickyActions,default} are disjoint
+            if ( recentActions_.contains( defaultAction ) ) {
+                defaultIndexInRecents = recentActions_.indexOf( defaultAction );
+                recentActions_.removeAt( defaultIndexInRecents );
+            }
+            defaultAction_ = defaultAction;
+        } else {
+            // It's in 'sticky' section, don't show it in 'default' section
+            defaultAction_ = NULL;
+        }
+    } else {
+        // New default is null, so clear the 'default' section
+        defaultAction_ = NULL;
+    }
+
+    // Push changes in model to view
+
+    // Add separator if needed and if it is not there
+    if ( ! stickyActions_.empty() || defaultAction_ != NULL ) {
+        if ( stickyAndDefaultSeparator_ == NULL )
+            stickyAndDefaultSeparator_ = encodingsMenu_->addSeparator();
+    } else {
+        if ( stickyAndDefaultSeparator_ != NULL )
+            encodingsMenu_->removeAction( stickyAndDefaultSeparator_ );
+    }
+
+    if ( oldDefaultAction != NULL )
+        encodingsMenu_->removeAction( oldDefaultAction );
+
+    if ( defaultIndexInRecents >= 0 )
+        encodingsMenu_->removeAction( defaultAction_ );
+
+    if ( defaultAction_ != NULL ) {
+        // Invariant: recents list is empty => recentSeparator is null => append;
+        //            otherwise insert before it
+        encodingsMenu_->insertAction( recentSeparator_, defaultAction_ );
+    }
+
+    // Add old default to recents section (convenient behavior)
+    if ( oldDefaultAction != NULL )
+        makeRecent( oldDefaultAction );
+}
+
+void EncodingSelector::makeRecent( QAction* action )
+{
+    // Invariant: recentActions and {stickyActions,default} are disjoint
+    // So, if it's in either sticky or default, then there's nothing to do
+    if ( stickyActions_.contains( action ) || action == defaultAction_ )
+        return;
+
+    // First remove from recents if it is already there, to reorder
+    int actionIndex = -1;
+    if ( recentActions_.contains( action ) ) {
+        actionIndex = recentActions_.indexOf( action );
+        recentActions_.removeAt( actionIndex );
+    }
+
+    // If recents are full: remove oldest
+    // Invariant: recentActions_.size() <= recentEncodings_->max()
+    QAction* oldestAction = NULL;
+    if ( recentActions_.size() > 0 &&
+         recentActions_.size() == recentEncodings_->max() ) {
+        oldestAction = recentActions_.last();
+        recentActions_.removeLast();
+    }
+
+    // Add to model
+    recentActions_.prepend( action );
+
+    // Remember in persistable collection
+    QString encoding = action->data().toString();
+    recordRecent( encoding );
+
+    // Invariant: recentActions_.size() >= 1 (we just appended)
+
+    // Push the above model changes to view
+
+    // If we added the first one: add the separator
+    if ( recentSeparator_ == NULL ) // will be the case on first add
+        recentSeparator_ = encodingsMenu_->addSeparator();
+
+    if ( actionIndex >= 0 )
+        encodingsMenu_->removeAction( action );
+    if ( oldestAction != NULL )
+        encodingsMenu_->removeAction( oldestAction );
+
+    // Insert before the first action (our action is at index 0)
+    QAction* followingAction = recentActions_.size() > 1 ?
+        recentActions_.at( 1 ) : NULL;
+    encodingsMenu_->insertAction( followingAction, action );
+}
+
+void EncodingSelector::recordRecent( const QString& encoding )
+{
+    // Push the encoding into the list of recents
+    // (reload the list first in case another glogg changed it)
+    // TODO: Encapsulate load-modify-save logic into persistables
+    GetPersistentInfo().retrieve( "recentEncodings" );
+    recentEncodings_->addRecent( encoding );
+    GetPersistentInfo().save( "recentEncodings" );
+}

--- a/encodingselector.cpp
+++ b/encodingselector.cpp
@@ -49,23 +49,33 @@ const QStringList& EncodingSelector::allEncodings()
 }
 
 EncodingSelector::EncodingSelector( Configuration* config,
-                                    RecentEncodings* recentEncodings,
+                                    RecentEncodings* recentEncodingsStore,
                                     QWidget* menuParent,
                                     QObject* parent )
     : QObject( parent )
     , menuParent_( menuParent )
     , config_( config )
-    , recentEncodings_( recentEncodings )
+    , recentEncodingsStore_( recentEncodingsStore )
     , actionGroup_( NULL )
-    , actions_()
-    , stickyActions_()
-    , recentActions_()
-    , defaultAction_( NULL )
+    , stickyEncodings_()
+    , recentEncodings_()
+    , defaultEncoding_()
     , stickyAndDefaultSeparator_( NULL )
     , recentSeparator_( NULL )
 {
-    createActions();
+    // We manage the checkmarks manually, since there are multiple
+    // actions for the same encoding (in different menu sections).
+    // NOTE: Unity/DBus doesn't like multiple ptrs to same action object in a
+    // menu.
+    actionGroup_ = new QActionGroup( this );
+    actionGroup_->setExclusive( false );
+    connect( actionGroup_, SIGNAL( triggered( QAction* ) ),
+             this, SLOT( changeEncoding( QAction* ) ) );
+
     createMenu();
+
+    selectedEncoding_ = config_->encoding();
+    updateCheckmarks();
 }
 
 QMenu* EncodingSelector::encodingsMenu() const
@@ -75,41 +85,36 @@ QMenu* EncodingSelector::encodingsMenu() const
 
 QString EncodingSelector::selectedEncoding() const
 {
-    QAction* action = actionGroup_->checkedAction();
-    if ( action == NULL )
-        return QString();
-    return action->data().toString();
+    return selectedEncoding_;
 }
 
 void EncodingSelector::applyConfiguration()
 {
-    changeDefaultEncoding();
+    changeDefaultEncoding( config_->encoding() );
 }
 
 void EncodingSelector::changeEncoding( QAction* action )
 {
-    makeRecent( action );
-    QString encoding = action->data().toString();
-    emit encodingChanged( encoding );
+    selectedEncoding_ = action->data().toString();
+    makeRecent( selectedEncoding_ );
+    updateCheckmarks();
+    emit encodingChanged( selectedEncoding_ );
 }
 
-void EncodingSelector::createActions()
+QAction* EncodingSelector::createAction( const QString& encoding,
+                                         QWidget* parent )
 {
-    const QStringList& encodings = EncodingSelector::allEncodings();
+    QAction* action = new QAction( encoding, parent );
+    action->setData( encoding ); // to not rely on display text
+    action->setCheckable( true );
+    action->setActionGroup( actionGroup_ );
+    return action;
+}
 
-    actionGroup_ = new QActionGroup( this );
-    connect( actionGroup_, SIGNAL( triggered( QAction* ) ),
-             this, SLOT( changeEncoding( QAction* ) ) );
-
-    foreach ( const QString& encoding, encodings ) {
-        QAction* action = new QAction( encoding, this );
-        action->setData( encoding ); // to not rely on display text
-        action->setCheckable( true );
-        action->setActionGroup( actionGroup_ );
-        if ( encoding == config_->encoding() )
-            action->setChecked( true );
-        actions_.insert( encoding, action );
-    }
+void EncodingSelector::destroyAction( QAction *action )
+{
+    actionGroup_->removeAction( action );
+    delete action;
 }
 
 void EncodingSelector::createMenu()
@@ -133,7 +138,8 @@ void EncodingSelector::createMoreEncodingsSection()
     moreEncodingsMenu_ = encodingsMenu_->addMenu( tr("&More encodings") );
     const QStringList& encodings = EncodingSelector::allEncodings();
     foreach ( const QString& encoding, encodings ) {
-        moreEncodingsMenu_->addAction( actions_[ encoding ] );
+        QAction* action = createAction( encoding, moreEncodingsMenu_ );
+        moreEncodingsMenu_->addAction( action );
     }
 }
 
@@ -143,110 +149,155 @@ void EncodingSelector::createStickySection()
     // a sticky action more than once since that causes re-ordering,
     // so we check membership before adding each one.
 
+    const QStringList& allEncodings = EncodingSelector::allEncodings();
+
     // Locale
     QString localeEncoding = QTextCodec::codecForLocale()->name();
-    if ( actions_.contains( localeEncoding ) ) {
-        QAction* action = actions_[ localeEncoding ];
-        if ( ! stickyActions_.contains( action ) )
-            stickyActions_.append( action );
+    if ( allEncodings.contains( localeEncoding ) &&
+         ! stickyEncodings_.contains( localeEncoding ) ) {
+        stickyEncodings_.append( localeEncoding );
     }
 
     // UTF-8
     const char utf8Encoding[] = "UTF-8";
-    if ( actions_.contains( utf8Encoding ) ) {
-        QAction* action = actions_[ utf8Encoding ];
-        if ( ! stickyActions_.contains( action ) )
-            stickyActions_.append( action );
+    if ( allEncodings.contains( utf8Encoding ) &&
+         ! stickyEncodings_.contains( utf8Encoding ) ) {
+        stickyEncodings_.append( utf8Encoding );
     }
 
     // Push from model to view
-    if ( ! stickyActions_.empty() ) {
+    if ( ! stickyEncodings_.empty() ) {
         stickyAndDefaultSeparator_ = encodingsMenu_->addSeparator();
-        foreach ( QAction* action, stickyActions_ )
+        foreach ( const QString& encoding, stickyEncodings_ ) {
+            QAction* action = createAction( encoding, encodingsMenu_ );
             encodingsMenu_->addAction( action );
+        }
     }
 }
 
 void EncodingSelector::createDefaultSection()
 {
+    const QStringList& allEncodings = EncodingSelector::allEncodings();
+
     // User-persisted default
-    if ( actions_.contains( config_->encoding() ) ) {
-        QAction* action = actions_[ config_->encoding() ];
-        if ( ! stickyActions_.contains( action ) )
-            defaultAction_ = action;
+    const QString& defaultEncoding = config_->encoding();
+    if ( allEncodings.contains( defaultEncoding ) &&
+         ! stickyEncodings_.contains( defaultEncoding ) ) {
+        defaultEncoding_ = defaultEncoding;
     }
 
     // Push from model to view
-    if ( defaultAction_ != NULL ) {
+    if ( defaultEncoding_ != "" ) {
         if ( stickyAndDefaultSeparator_ == NULL )
             stickyAndDefaultSeparator_ = encodingsMenu_->addSeparator();
-        encodingsMenu_->addAction( defaultAction_ );
+
+        QAction* action = createAction( defaultEncoding_, encodingsMenu_ );
+        encodingsMenu_->addAction( action );
     }
 }
 
 void EncodingSelector::createRecentSection()
 {
+    const QStringList& allEncodings = EncodingSelector::allEncodings();
+
     // Resolve encoding names into actions and add them to model
-    foreach ( QString encoding, recentEncodings_->recentEncodings() ) {
-        if (  actions_.contains( encoding )) {
-            QAction* action = actions_[ encoding ];
+    foreach ( QString encoding, recentEncodingsStore_->recentEncodings() ) {
+        if (  allEncodings.contains( encoding )) {
             // Invariant: recentActions and {stickyActions,default} are disjoint
-            if ( ! stickyActions_.contains( action ) &&
-                 action != defaultAction_ ) {
-                recentActions_.append( action );
+            if ( ! stickyEncodings_.contains( encoding ) &&
+                 encoding != defaultEncoding_ ) {
+                recentEncodings_.append( encoding );
             }
         }
     }
 
     // Push from model to view
-    if ( ! recentActions_.empty() ) {
+    if ( ! recentEncodings_.empty() ) {
         recentSeparator_ = encodingsMenu_->addSeparator();
-        foreach ( QAction* action, recentActions_ ) {
+        foreach ( const QString& encoding, recentEncodings_ ) {
+            QAction* action = createAction( encoding, encodingsMenu_ );
             encodingsMenu_->addAction( action );
         }
     }
 }
 
-void EncodingSelector::changeDefaultEncoding()
+void EncodingSelector::updateCheckmarks()
+{
+    const QMenu* sections[] = {
+        moreEncodingsMenu_,
+        encodingsMenu_,
+        NULL
+    };
+    for (int i = 0; sections[i] != NULL; ++i) {
+        foreach ( QAction* action, sections[i]->actions() ) {
+            if ( action->data().toString() == selectedEncoding_ )
+                action->setChecked( true );
+            else
+                action->setChecked( false);
+        }
+    }
+}
+
+int EncodingSelector::recentIndexToMenuIndex( int recentIndex )
+{
+    // List of recent items doesn't start at zero in the menu, so calculate
+    return 1 + // more encodings
+           ( stickyAndDefaultSeparator_ != NULL ? 1 : 0 ) +
+           stickyEncodings_.size() +
+           ( defaultEncoding_ != "" ? 1 : 0 ) +
+           ( recentSeparator_ != NULL ? 1 : 0 ) +
+           recentIndex;
+}
+
+int EncodingSelector::defaultEncodingMenuIndex()
+{
+    return 1 + // more encodings
+           ( stickyAndDefaultSeparator_ != NULL ? 1 : 0 ) +
+           stickyEncodings_.length();
+}
+
+void EncodingSelector::changeDefaultEncoding( const QString& encoding )
 {
     // This method updates the menu item corresponding to persisted
     // user-selected default encoding. We assume that the default goes right
     // before the recents separator.
 
-    // Get the new default
-    QAction* defaultAction = NULL;
-    if ( actions_.contains( config_->encoding() ) )
-        defaultAction = actions_[ config_->encoding() ];
+    const QStringList& allEncodings = EncodingSelector::allEncodings();
+
+    // The new default
+    QString defaultEncoding = "";
+    if ( allEncodings.contains( encoding ) )
+        defaultEncoding = encoding;
 
     // Check if there was any change at all
-    if ( defaultAction == defaultAction_ )
+    if ( defaultEncoding == defaultEncoding_ )
         return;
 
     // Update the model
-    QAction* oldDefaultAction = defaultAction_;
+    QString oldDefaultEncoding = defaultEncoding_;
     int defaultIndexInRecents = -1;
-    if ( defaultAction != NULL ) {
-        if ( ! stickyActions_.contains( defaultAction ) ) {
+    if ( defaultEncoding != "" ) {
+        if ( ! stickyEncodings_.contains( defaultEncoding ) ) {
             // Remove the new one in case it appears in recents
             // Invariant: recentActions and {stickyActions,default} are disjoint
-            if ( recentActions_.contains( defaultAction ) ) {
-                defaultIndexInRecents = recentActions_.indexOf( defaultAction );
-                recentActions_.removeAt( defaultIndexInRecents );
+            if ( recentEncodings_.contains( defaultEncoding ) ) {
+                defaultIndexInRecents = recentEncodings_.indexOf( defaultEncoding );
+                recentEncodings_.removeAt( defaultIndexInRecents );
             }
-            defaultAction_ = defaultAction;
+            defaultEncoding_ = defaultEncoding;
         } else {
             // It's in 'sticky' section, don't show it in 'default' section
-            defaultAction_ = NULL;
+            defaultEncoding_ = "";
         }
     } else {
         // New default is null, so clear the 'default' section
-        defaultAction_ = NULL;
+        defaultEncoding_ = "";
     }
 
     // Push changes in model to view
 
     // Add separator if needed and if it is not there
-    if ( ! stickyActions_.empty() || defaultAction_ != NULL ) {
+    if ( ! stickyEncodings_.empty() || defaultEncoding_ != "" ) {
         if ( stickyAndDefaultSeparator_ == NULL )
             stickyAndDefaultSeparator_ = encodingsMenu_->addSeparator();
     } else {
@@ -254,54 +305,68 @@ void EncodingSelector::changeDefaultEncoding()
             encodingsMenu_->removeAction( stickyAndDefaultSeparator_ );
     }
 
-    if ( oldDefaultAction != NULL )
-        encodingsMenu_->removeAction( oldDefaultAction );
+    if ( oldDefaultEncoding != "") {
+        // The default menu item is the one after 'sticky' section
+        const QList<QAction*>& actions = encodingsMenu_->actions();
+        QAction* action = actions.at( defaultEncodingMenuIndex() );
+        encodingsMenu_->removeAction( action );
+        destroyAction( action );
+    }
 
-    if ( defaultIndexInRecents >= 0 )
-        encodingsMenu_->removeAction( defaultAction_ );
+    if ( defaultIndexInRecents >= 0 ) {
+        const QList<QAction*>& actions = encodingsMenu_->actions();
+        QAction* action =
+            // -1 because there is no default enc item (invariant at this point)
+            actions.at( recentIndexToMenuIndex( defaultIndexInRecents ) - 1 );
+        encodingsMenu_->removeAction( action );
+        destroyAction( action );
+    }
 
-    if ( defaultAction_ != NULL ) {
+    if ( defaultEncoding_ != "" ) {
         // Invariant: recents list is empty => recentSeparator is null => append;
         //            otherwise insert before it
-        encodingsMenu_->insertAction( recentSeparator_, defaultAction_ );
+        QAction* action = createAction( defaultEncoding, encodingsMenu_ );
+        encodingsMenu_->insertAction( recentSeparator_, action );
     }
 
     // Add old default to recents section (convenient behavior)
-    if ( oldDefaultAction != NULL )
-        makeRecent( oldDefaultAction );
+    if ( oldDefaultEncoding != "" )
+        makeRecent( oldDefaultEncoding );
+
+    // Actions might have been added to menus, so need to update checkmarks
+    updateCheckmarks();
 }
 
-void EncodingSelector::makeRecent( QAction* action )
+void EncodingSelector::makeRecent( const QString& encoding )
 {
     // Invariant: recentActions and {stickyActions,default} are disjoint
     // So, if it's in either sticky or default, then there's nothing to do
-    if ( stickyActions_.contains( action ) || action == defaultAction_ )
+    if ( stickyEncodings_.contains( encoding ) || encoding == defaultEncoding_ )
         return;
 
     // First remove from recents if it is already there, to reorder
-    int actionIndex = -1;
-    if ( recentActions_.contains( action ) ) {
-        actionIndex = recentActions_.indexOf( action );
-        recentActions_.removeAt( actionIndex );
+    int encodingIndexInRecents = -1;
+    if ( recentEncodings_.contains( encoding ) ) {
+        encodingIndexInRecents = recentEncodings_.indexOf( encoding );
+        recentEncodings_.removeAt( encodingIndexInRecents );
     }
 
     // If recents are full: remove oldest
-    // Invariant: recentActions_.size() <= recentEncodings_->max()
-    QAction* oldestAction = NULL;
-    if ( recentActions_.size() > 0 &&
-         recentActions_.size() == recentEncodings_->max() ) {
-        oldestAction = recentActions_.last();
-        recentActions_.removeLast();
+    // Invariant: recentEncodings_.size() <= recentEncodings_->max()
+    int oldestActionIndexInRecents = -1;
+    if ( recentEncodings_.size() > 0 &&
+         recentEncodings_.size() == recentEncodingsStore_->max() ) {
+        oldestActionIndexInRecents = recentEncodings_.size() - 1;
+        recentEncodings_.removeLast();
     }
 
     // Add to model
-    recentActions_.prepend( action );
+    recentEncodings_.prepend( encoding );
 
     // Remember in persistable collection
-    QString encoding = action->data().toString();
     recordRecent( encoding );
 
-    // Invariant: recentActions_.size() >= 1 (we just appended)
+    // Invariant: recentEncodings_.size() >= 1 (we just appended)
 
     // Push the above model changes to view
 
@@ -309,15 +374,30 @@ void EncodingSelector::makeRecent( QAction* action )
     if ( recentSeparator_ == NULL ) // will be the case on first add
         recentSeparator_ = encodingsMenu_->addSeparator();
 
-    if ( actionIndex >= 0 )
+    if ( encodingIndexInRecents >= 0 ) {
+        const QList<QAction*>& actions = encodingsMenu_->actions();
+        QAction* action =
+            actions.at( recentIndexToMenuIndex( encodingIndexInRecents ) );
         encodingsMenu_->removeAction( action );
-    if ( oldestAction != NULL )
-        encodingsMenu_->removeAction( oldestAction );
+        destroyAction( action );
+    }
+    // TODO: adjust the menu item index corresponding to
+    // oldestActionIndexInRecents based on encodingIndexInRecents
+    if ( oldestActionIndexInRecents >= 0 ) {
+        const QList<QAction*>& actions = encodingsMenu_->actions();
+        QAction* action =
+            actions.at( recentIndexToMenuIndex( oldestActionIndexInRecents ) );
+        encodingsMenu_->removeAction( action );
+        destroyAction( action );
+    }
 
     // Insert before the first action (our action is at index 0)
-    QAction* followingAction = recentActions_.size() > 1 ?
-        recentActions_.at( 1 ) : NULL;
-    encodingsMenu_->insertAction( followingAction, action );
+    QAction* recentAction = createAction( encoding, encodingsMenu_ );
+    const QList<QAction*>& actions = encodingsMenu_->actions();
+    // First action in the recent list before the new recent was prepended
+    QAction* followingAction = recentEncodings_.size() <= 1 ?  NULL :
+        actions.at( recentIndexToMenuIndex( 0 ) );
+    encodingsMenu_->insertAction( followingAction, recentAction );
 }
 
 void EncodingSelector::recordRecent( const QString& encoding )
@@ -326,6 +406,6 @@ void EncodingSelector::recordRecent( const QString& encoding )
     // (reload the list first in case another glogg changed it)
     // TODO: Encapsulate load-modify-save logic into persistables
     GetPersistentInfo().retrieve( "recentEncodings" );
-    recentEncodings_->addRecent( encoding );
+    recentEncodingsStore_->addRecent( encoding );
     GetPersistentInfo().save( "recentEncodings" );
 }

--- a/encodingselector.h
+++ b/encodingselector.h
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2009, 2010, 2011 Nicolas Bonnefon and other contributors
+ *
+ * This file is part of glogg.
+ *
+ * glogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * glogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with glogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ENCODINGSELECTOR_H
+#define ENCODINGSELECTOR_H
+
+#include <QString>
+#include <QList>
+#include <QHash>
+
+class QObject;
+class QWidget;
+class QMenu;
+class QAction;
+class QActionGroup;
+class QStringList;
+
+class Configuration;
+class RecentEncodings;
+
+// Provides a menu for choosing encodings
+//
+// The menu is composed of four sections: list of all known encodings,
+// a list of a few permanently-visible encodings for convenience, the
+// user-specified default encoding from options, and a list
+// of recently used encodings. Note that there is no separator between
+// sticky and default sections to minimize number of separators.
+//
+// Implementation notes: the logic is implemented by operating on the models
+// corresponding to the different sections of the menu. When the models are
+// modified, the modifications are pushed to the view (the actual menu). This
+// means that there should never be the need to read from the menu.
+class EncodingSelector : public QObject
+{
+    Q_OBJECT
+
+  public:
+    // List of all known encodings (sorted alphabetically, aliases kept)
+    static const QStringList& allEncodings();
+
+  public:
+    EncodingSelector( Configuration* config, RecentEncodings* recentEncodings,
+                      QWidget* menuParent, QObject* parent = 0 );
+
+  private:
+    EncodingSelector( const EncodingSelector& );
+    EncodingSelector& operator=( const EncodingSelector& );
+
+  public:
+
+    // The menu used to choose encoding
+    QMenu* encodingsMenu() const;
+
+    // Currently selected encoding
+    QString selectedEncoding() const;
+
+  public slots:
+    void applyConfiguration();
+
+  signals:
+    void encodingChanged( const QString& encoding );
+
+  private slots:
+    void changeEncoding( QAction* encodingAction );
+
+  private:
+    void createActions();
+    void createMenu();
+    void createMoreEncodingsSection();
+    void createStickySection();
+    void createDefaultSection();
+    void createRecentSection();
+
+    // Updates the default-encoding item in the menu
+    void changeDefaultEncoding();
+
+    // Perform necessary steps to mark the encoding as recently-used
+    void makeRecent( QAction* action );
+
+    // Remember encoding as recently-used by adding to persistable collection
+    void recordRecent( const QString& encoding );
+
+    // This widget will be used as the menu parent
+    QWidget* menuParent_;
+
+    Configuration* config_;
+    RecentEncodings* recentEncodings_;
+
+    QMenu* encodingsMenu_;
+    QMenu* moreEncodingsMenu_;
+
+    // All encoding actions are in this group
+    QActionGroup* actionGroup_;
+
+    // Stores the action for each encoding known to the selector
+    // Maps: encoding name -> action
+    QHash<QString, QAction*> actions_;
+
+    // Model collection for the menu section with permanently-visible encodings
+    // Invariant: disjoint with recentActions_
+    QList<QAction*> stickyActions_;
+
+    // Model collection for the menu section with recently used encodings
+    // (ordered newest to oldest)
+    // Invariant: disjoint with {stickyActions,default}
+    QList<QAction*> recentActions_;
+
+    // Model menu item for the default encoding set in options
+    // Invariant: not in {stickyActions,recentActions}
+    QAction* defaultAction_;
+
+    // Separator before the sticky+default sections and the recents section
+    // We don't explicitly separate sticky+default, so they share this separator
+    // Invariant: not null if {stickyActions,default} is not empty
+    QAction* stickyAndDefaultSeparator_;
+
+    // Separator before the sticky section
+    // Invariant: not null if recentActions_ is not empty
+    QAction* recentSeparator_;
+
+};
+
+#endif

--- a/glogg.pro
+++ b/glogg.pro
@@ -34,10 +34,12 @@ SOURCES += main.cpp \
     quickfindwidget.cpp \
     sessioninfo.cpp \
     recentfiles.cpp \
+    recentencodings.cpp \
     menuactiontooltipbehavior.cpp \
     overview.cpp \
     overviewwidget.cpp \
-    marks.cpp
+    marks.cpp \
+    encodingselector.cpp
 
 HEADERS += \
     mainwindow.h \
@@ -66,10 +68,12 @@ HEADERS += \
     sessioninfo.h \
     persistable.h \
     recentfiles.h \
+    recentencodings.h \
     menuactiontooltipbehavior.h \
     overview.h \
     overviewwidget.h \
-    marks.h
+    marks.h \
+    encodingselector.h
 
 isEmpty(BOOST_PATH) {
     message(Building using system dynamic Boost libraries)

--- a/logdata.h
+++ b/logdata.h
@@ -32,6 +32,7 @@
 #include "filewatcher.h"
 
 class LogFilteredData;
+class QTextCodec;
 
 // Represents a complete set of data to be displayed (ie. a log file content)
 // This class is thread-safe.
@@ -63,6 +64,8 @@ class LogData : public AbstractLogData {
     // Returns the last modification date for the file.
     // Null if the file is not on disk.
     QDateTime getLastModifiedDate() const;
+    // Sets the codec to use for interpreting the data
+    void setCodec( QTextCodec* codec );
 
   signals:
     // Sent during the 'attach' process to signal progress
@@ -156,6 +159,8 @@ class LogData : public AbstractLogData {
     void enqueueOperation( const LogDataOperation* newOperation );
     void startOperation();
 
+    QString toUnicode( QByteArray rawString ) const;
+
     QString indexingFileName_;
     QFile* file_;
     LinePositionArray linePosition_;
@@ -163,6 +168,8 @@ class LogData : public AbstractLogData {
     qint64 nbLines_;
     int maxLength_;
     QDateTime lastModifiedDate_;
+    QTextCodec* codec_;
+
     const LogDataOperation* currentOperation_;
     const LogDataOperation* nextOperation_;
 

--- a/main.cpp
+++ b/main.cpp
@@ -30,6 +30,7 @@ using namespace std;
 #include "configuration.h"
 #include "filterset.h"
 #include "recentfiles.h"
+#include "recentencodings.h"
 #include "mainwindow.h"
 #include "savedsearches.h"
 #include "log.h"
@@ -127,6 +128,8 @@ int main(int argc, char *argv[])
             new SavedSearches, QString( "savedSearches" ) );
     GetPersistentInfo().registerPersistable(
             new RecentFiles, QString( "recentFiles" ) );
+    GetPersistentInfo().registerPersistable(
+            new RecentEncodings, QString( "recentEncodings" ) );
 
     // FIXME: should be replaced by a two staged init of MainWindow
     GetPersistentInfo().retrieve( QString( "settings" ) );

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -21,11 +21,15 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
+
 #include "crawlerwidget.h"
 #include "infoline.h"
 
 class QAction;
+
 class RecentFiles;
+class RecentEncodings;
+class EncodingSelector;
 class MenuActionToolTipBehavior;
 
 // Main window of the application, creates menus, toolbar and
@@ -74,7 +78,6 @@ class MainWindow : public QMainWindow
     // without the progress gauge and with file info
     void displayNormalStatus( bool success );
 
-
   signals:
     // Is emitted when new settings must be used
     void optionsChanged();
@@ -88,6 +91,7 @@ class MainWindow : public QMainWindow
     void createToolBars();
     void createStatusBar();
     void createCrawler();
+    void createEncodingSelector();
     void createRecentFileToolTipTimer();
     void readSettings();
     void writeSettings();
@@ -101,6 +105,7 @@ class MainWindow : public QMainWindow
     SavedSearches *savedSearches;
     CrawlerWidget *crawlerWidget;
     RecentFiles& recentFiles;
+    RecentEncodings *recentEncodings;
     QString loadingFileName;
     QString currentFile;
     QString previousFile;
@@ -119,7 +124,7 @@ class MainWindow : public QMainWindow
     InfoLine *infoLine;
     QLabel* lineNbField;
     QToolBar *toolBar;
-    QComboBox *encodingBox;
+    EncodingSelector *encodingSelector;
 
     QAction *openAction;
     QAction *exitAction;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -119,6 +119,7 @@ class MainWindow : public QMainWindow
     InfoLine *infoLine;
     QLabel* lineNbField;
     QToolBar *toolBar;
+    QComboBox *encodingBox;
 
     QAction *openAction;
     QAction *exitAction;

--- a/optionsdialog.cpp
+++ b/optionsdialog.cpp
@@ -24,6 +24,7 @@
 #include "log.h"
 #include "persistentinfo.h"
 #include "configuration.h"
+#include "encodingselector.h"
 
 // Constructor
 OptionsDialog::OptionsDialog( QWidget* parent ) : QDialog(parent)
@@ -103,21 +104,9 @@ void OptionsDialog::updateDialogFromConfig()
     quickFindSearchBox->setCurrentIndex(
             getRegexpIndex( config.quickfindRegexpType() ) );
 
-    // Sort the available encodings; display all aliases
-    QMap<QString, QString> encodings;
-    foreach ( QByteArray encoding, QTextCodec::availableCodecs() ) {
-        QString encodingStr( encoding );
-        const QString& encodingStrLower = encodingStr.toLower();
-        encodings.insert( encodingStrLower, encodingStr );
-    }
-    QStringList encodingList;
-    foreach ( QString encoding, encodings ) {
-        encodingList.append( encoding );
-    } 
-    defaultEncodingBox->addItems( encodingList );
+    defaultEncodingBox->addItems( EncodingSelector::allEncodings() );
 
     const QString& encoding = config.encoding();
-
     int encodingIndex =
         defaultEncodingBox->findText( encoding, Qt::MatchFixedString);
     if ( encodingIndex != -1 )

--- a/optionsdialog.cpp
+++ b/optionsdialog.cpp
@@ -102,6 +102,26 @@ void OptionsDialog::updateDialogFromConfig()
             getRegexpIndex( config.mainRegexpType() ) );
     quickFindSearchBox->setCurrentIndex(
             getRegexpIndex( config.quickfindRegexpType() ) );
+
+    // Sort the available encodings; display all aliases
+    QMap<QString, QString> encodings;
+    foreach ( QByteArray encoding, QTextCodec::availableCodecs() ) {
+        QString encodingStr( encoding );
+        const QString& encodingStrLower = encodingStr.toLower();
+        encodings.insert( encodingStrLower, encodingStr );
+    }
+    QStringList encodingList;
+    foreach ( QString encoding, encodings ) {
+        encodingList.append( encoding );
+    } 
+    defaultEncodingBox->addItems( encodingList );
+
+    const QString& encoding = config.encoding();
+
+    int encodingIndex =
+        defaultEncodingBox->findText( encoding, Qt::MatchFixedString);
+    if ( encodingIndex != -1 )
+        defaultEncodingBox->setCurrentIndex( encodingIndex );
 }
 
 //
@@ -137,6 +157,9 @@ void OptionsDialog::updateConfigFromDialog()
             getRegexpTypeFromIndex( mainSearchBox->currentIndex() ) );
     config.setQuickfindRegexpType(
             getRegexpTypeFromIndex( quickFindSearchBox->currentIndex() ) );
+
+    QString encoding = defaultEncodingBox->currentText();
+    config.setEncoding( encoding );
 
     emit optionsChanged();
 }

--- a/optionsdialog.ui
+++ b/optionsdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>411</width>
-    <height>262</height>
+    <height>356</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -23,7 +23,7 @@
    <property name="geometry">
     <rect>
      <x>60</x>
-     <y>220</y>
+     <y>300</y>
      <width>341</width>
      <height>32</height>
     </rect>
@@ -121,6 +121,41 @@
      </item>
      <item>
       <widget class="QComboBox" name="fontSizeBox"/>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <widget class="QGroupBox" name="encodingBox">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>210</y>
+     <width>389</width>
+     <height>71</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string>Encoding</string>
+   </property>
+   <widget class="QWidget" name="horizontalLayoutWidget_2">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>30</y>
+      <width>371</width>
+      <height>31</height>
+     </rect>
+    </property>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Default encoding:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="defaultEncodingBox"/>
      </item>
     </layout>
    </widget>

--- a/recentencodings.cpp
+++ b/recentencodings.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2011 Nicolas Bonnefon and other contributors
+ *
+ * This file is part of glogg.
+ *
+ * glogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * glogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with glogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// This file implements class RecentEncodings
+
+#include <QSettings>
+#include <QTextCodec>
+
+#include "log.h"
+#include "recentencodings.h"
+
+const int RecentEncodings::RECENTENCODINGS_VERSION = 1;
+const int RecentEncodings::MAX_NUMBER_OF_ENCODINGS = 5;
+
+RecentEncodings::RecentEncodings() : recentEncodings_()
+{
+}
+
+int RecentEncodings::max()
+{
+    return MAX_NUMBER_OF_ENCODINGS;
+}
+
+void RecentEncodings::addRecent( const QString& encoding )
+{
+    // Invariant: no duplicates
+    recentEncodings_.removeAll( encoding );
+
+    // Add at the front
+    recentEncodings_.push_front( encoding );
+
+    // Trim the list if it's too long
+    while ( recentEncodings_.size() > MAX_NUMBER_OF_ENCODINGS )
+        recentEncodings_.pop_back();
+}
+
+QStringList RecentEncodings::recentEncodings() const
+{
+    return recentEncodings_;
+}
+
+//
+// Persistable virtual functions implementation
+//
+
+void RecentEncodings::saveToStorage( QSettings& settings ) const
+{
+    LOG(logDEBUG) << "RecentEncodings::saveToStorage";
+
+    settings.beginGroup( "RecentEncodings" );
+    settings.setValue( "version", RECENTENCODINGS_VERSION );
+    settings.beginWriteArray( "encodingsHistory" );
+    for (int i = 0; i < recentEncodings_.size(); ++i) {
+        settings.setArrayIndex( i );
+        settings.setValue( "name", recentEncodings_.at( i ) );
+    }
+    settings.endArray();
+    settings.endGroup();
+}
+
+void RecentEncodings::retrieveFromStorage( QSettings& settings )
+{
+    LOG(logDEBUG) << "RecentEncodings::retrieveFromStorage";
+
+    recentEncodings_.clear();
+
+    if ( settings.contains( "RecentEncodings/version" ) ) {
+        // Unserialise the "new style" stored history
+        settings.beginGroup( "RecentEncodings" );
+        if ( settings.value( "version" ) == RECENTENCODINGS_VERSION ) {
+            int size = settings.beginReadArray( "encodingsHistory" );
+            if ( size > MAX_NUMBER_OF_ENCODINGS ) {
+                LOG(logINFO) << "More persisted encodings (" << size << ") "
+                    << "than maximum (" << MAX_NUMBER_OF_ENCODINGS << "): "
+                    << "skipped the extra";
+            }
+            const int count = qMin( size, MAX_NUMBER_OF_ENCODINGS );
+            for (int i = 0; i < count; ++i) {
+                settings.setArrayIndex(i);
+                QString encoding = settings.value( "name" ).toString();
+                // Don't trust persisted data: might come from another system
+                // NOTE: This introduces a delay on startup, since this causes
+                // the codecs (for these recently used encodings) to actually
+                // be loaded. This is not strictly necessary, however handling
+                // a possibly invalid codec that's already in the menu does
+                // not sound appealing -- so validating here for now.
+                if ( QTextCodec::codecForName( encoding.toUtf8() ) )
+                    recentEncodings_.append( encoding );
+                else
+                    LOG(logINFO) << "Unsupported persisted encoding '"
+                        << encoding.toStdString() << "': skipped";
+            }
+            settings.endArray();
+        }
+        else {
+            LOG(logERROR)
+                << "Unknown version of RecentEncodings, ignoring it...";
+        }
+        settings.endGroup();
+    }
+}

--- a/recentencodings.h
+++ b/recentencodings.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2011 Nicolas Bonnefon and other contributors
+ *
+ * This file is part of glogg.
+ *
+ * glogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * glogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with glogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef RECENTENCODINGS_H
+#define RECENTENCODINGS_H
+
+#include <QString>
+#include <QStringList>
+
+#include "persistable.h"
+
+// Manage the list of recently used encodings
+class RecentEncodings : public Persistable
+{
+  public:
+    // Creates an empty set of recent encodings
+    RecentEncodings();
+
+    // Maximum encodings that are saved before rolling over
+    int max();
+
+    // Adds the passed encoding to the list of recently used encodings
+    void addRecent( const QString& encoding );
+
+    // Returns a list of recent encodings (most recent first)
+    QStringList recentEncodings() const;
+
+    // Reads/writes the current encoding list into the passed QSettings object
+    virtual void saveToStorage( QSettings& settings ) const;
+    virtual void retrieveFromStorage( QSettings& settings );
+
+  private:
+    static const int RECENTENCODINGS_VERSION;
+    static const int MAX_NUMBER_OF_ENCODINGS;
+
+    QStringList recentEncodings_;
+};
+
+#endif


### PR DESCRIPTION
The first patch (a slightly adjusted version of original patch from Stanislav Sikora) implements some support for different encodings. The second patch is an implementation of a encoding selector in the view menu with a few useful features.

I'm afraid that the first patch is not a complete solution to Issue 16 and Issue 25 because it converts at display time. I'm no expert, but I think the conversion needs to be done at time of reading the file in order to correctly split up the content into lines. Maybe using QTextStream::setCodec(). That said, the current scheme does work in many (most?) cases. One counter example is UTF16-LE (file created in gedit with either line endings): only first line is converted. Not sure what's the success rate, but if it's high enough, maybe we could release it as is.

The second patch with the EncodingSelector is UI for encoding selection (original patch had a control in the main view, but this stuff should be in View menu instead, which is also consistent with other apps). This patch should be usable regardless of what implementation of the actual encoding conversion we settle on. It's a simple menu which maintains the list of all encodings, common encodings, the default encoding (as defined by previous patch), and recently used encodings. In the future, we could make the list of 'pinned' encodings customizable like in many other apps (e.g. Firefox), but that's not crucial given the recently-used list.
