### PR TITLE
Fix for chunk width calculation: char bearings

### DIFF
--- a/abstractlogview.cpp
+++ b/abstractlogview.cpp
@@ -109,14 +109,17 @@ inline void LineDrawer::draw( QPainter& painter,
 {
     QFontMetrics fm = painter.fontMetrics();
     const int fontHeight = fm.height();
-    const int fontWidth = fm.maxWidth();
     const int fontAscent = fm.ascent();
 
     foreach ( Chunk chunk, list ) {
         // Draw each chunk
         // LOG(logDEBUG) << "Chunk: " << chunk.start() << " " << chunk.length();
         QString cutline = line.mid( chunk.start(), chunk.length() );
-        const int chunk_width = cutline.length() * fontWidth;
+        // Note that fm.width is not the same as len * maxWidth due to
+        // bearings.  We could use the latter and take bearings into account,
+        // but perhaps the font metics already makes width() efficient for
+        // fixed width fonts.
+        const int chunk_width = fm.width( cutline );
         painter.fillRect( xPos, yPos, chunk_width,
                 fontHeight, chunk.backColor() );
         painter.setPen( chunk.foreColor() );


### PR DESCRIPTION
This fixes a bug introduced in 7a5d77672e884ed64402da2051b0f8daa2bbc5ec.
Chunks for highlights or selection were drawn off by one pixel
because the chunk width calculation did not take into account character
bearings. This commit reverts the chunk width calculation to what it
was before.
