### PR TITLE
Add missing QDataStream headers.

### DIFF
--- a/src/filterset.cpp
+++ b/src/filterset.cpp
@@ -20,6 +20,7 @@
 // This file implements classes Filter and FilterSet
 
 #include <QSettings>
+#include <QDataStream>
 
 #include "log.h"
 #include "filterset.h"

--- a/src/savedsearches.cpp
+++ b/src/savedsearches.cpp
@@ -20,6 +20,7 @@
 // This file implements class SavedSearch
 
 #include <QSettings>
+#include <QDataStream>
 
 #include "log.h"
 #include "savedsearches.h"


### PR DESCRIPTION
These headers are needed to fix a build failure in Fedora Rawhide, using Qt5.