### PR TITLE
Atomic interrupt request

### DIFF
--- a/glogg.pro
+++ b/glogg.pro
@@ -96,6 +96,7 @@ HEADERS += \
     src/externalcom.h \
     src/viewtools.h \
     src/encodingspeculator.h \
+    src/data/atomicflag.h
 
 isEmpty(BOOST_PATH) {
     message(Building using system dynamic Boost libraries)

--- a/src/data/atomicflag.h
+++ b/src/data/atomicflag.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2009, 2010, 2013, 2014, 2015 Nicolas Bonnefon and other contributors
+ *
+ * This file is part of glogg.
+ *
+ * glogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * glogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with glogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ATOMICFLAG_H
+#define ATOMICFLAG_H
+
+#include <QAtomicInt>
+
+class AtomicFlag
+{
+public:
+	explicit AtomicFlag(bool initialState = false)
+	{
+		flag_.storeRelease(initialState ? 1 : 0);
+	}
+
+	inline void set()
+	{
+		flag_.storeRelease(1);
+	}
+
+	inline void clear()
+	{
+		flag_.storeRelease(0);
+	}
+
+	inline operator bool() const
+	{
+		return !!flag_.loadAcquire();
+	}
+
+	inline bool operator!() const
+	{
+		return !flag_.loadAcquire();
+	}
+
+private:
+	QAtomicInt flag_;
+};
+
+#endif // ATOMICFLAG_H

--- a/src/data/atomicflag.h
+++ b/src/data/atomicflag.h
@@ -25,33 +25,33 @@
 class AtomicFlag
 {
 public:
-	explicit AtomicFlag(bool initialState = false)
-	{
-		flag_.storeRelease(initialState ? 1 : 0);
-	}
+    explicit AtomicFlag(bool initialState = false)
+    {
+        flag_.storeRelease(initialState ? 1 : 0);
+    }
 
-	inline void set()
-	{
-		flag_.storeRelease(1);
-	}
+    inline void set()
+    {
+        flag_.storeRelease(1);
+    }
 
-	inline void clear()
-	{
-		flag_.storeRelease(0);
-	}
+    inline void clear()
+    {
+        flag_.storeRelease(0);
+    }
 
-	inline operator bool() const
-	{
-		return !!flag_.loadAcquire();
-	}
+    inline operator bool() const
+    {
+        return !!flag_.loadAcquire();
+    }
 
-	inline bool operator!() const
-	{
-		return !flag_.loadAcquire();
-	}
+    inline bool operator!() const
+    {
+        return !flag_.loadAcquire();
+    }
 
 private:
-	QAtomicInt flag_;
+    QAtomicInt flag_;
 };
 
 #endif // ATOMICFLAG_H

--- a/src/data/logdataworkerthread.h
+++ b/src/data/logdataworkerthread.h
@@ -30,6 +30,7 @@
 #include "linepositionarray.h"
 #include "encodingspeculator.h"
 #include "utils.h"
+#include "atomicflag.h"
 
 // This class is a thread-safe set of indexing data.
 class IndexingData
@@ -78,7 +79,7 @@ class IndexOperation : public QObject
   Q_OBJECT
   public:
     IndexOperation( const QString& fileName,
-            IndexingData* indexingData, bool* interruptRequest,
+			IndexingData* indexingData, AtomicFlag* interruptRequest,
             EncodingSpeculator* encodingSpeculator );
 
     virtual ~IndexOperation() { }
@@ -99,7 +100,7 @@ class IndexOperation : public QObject
             qint64 initialPosition );
 
     QString fileName_;
-    bool* interruptRequest_;
+	AtomicFlag* interruptRequest_;
     IndexingData* indexing_data_;
 
     EncodingSpeculator* encoding_speculator_;
@@ -109,7 +110,7 @@ class FullIndexOperation : public IndexOperation
 {
   public:
     FullIndexOperation( const QString& fileName,
-            IndexingData* indexingData, bool* interruptRequest,
+			IndexingData* indexingData, AtomicFlag* interruptRequest,
             EncodingSpeculator* speculator )
         : IndexOperation( fileName, indexingData, interruptRequest, speculator ) { }
     virtual bool start();
@@ -119,7 +120,7 @@ class PartialIndexOperation : public IndexOperation
 {
   public:
     PartialIndexOperation( const QString& fileName, IndexingData* indexingData,
-            bool* interruptRequest, EncodingSpeculator* speculator, qint64 position );
+			AtomicFlag* interruptRequest, EncodingSpeculator* speculator, qint64 position );
     virtual bool start();
 
   private:
@@ -178,8 +179,8 @@ class LogDataWorkerThread : public QThread
     QString fileName_;
 
     // Set when the thread must die
-    bool terminate_;
-    bool interruptRequested_;
+	AtomicFlag terminate_;
+	AtomicFlag interruptRequested_;
     IndexOperation* operationRequested_;
 
     // Pointer to the owner's indexing data (we modify it)

--- a/src/data/logdataworkerthread.h
+++ b/src/data/logdataworkerthread.h
@@ -79,7 +79,7 @@ class IndexOperation : public QObject
   Q_OBJECT
   public:
     IndexOperation( const QString& fileName,
-			IndexingData* indexingData, AtomicFlag* interruptRequest,
+            IndexingData* indexingData, AtomicFlag* interruptRequest,
             EncodingSpeculator* encodingSpeculator );
 
     virtual ~IndexOperation() { }
@@ -100,7 +100,7 @@ class IndexOperation : public QObject
             qint64 initialPosition );
 
     QString fileName_;
-	AtomicFlag* interruptRequest_;
+    AtomicFlag* interruptRequest_;
     IndexingData* indexing_data_;
 
     EncodingSpeculator* encoding_speculator_;
@@ -110,7 +110,7 @@ class FullIndexOperation : public IndexOperation
 {
   public:
     FullIndexOperation( const QString& fileName,
-			IndexingData* indexingData, AtomicFlag* interruptRequest,
+            IndexingData* indexingData, AtomicFlag* interruptRequest,
             EncodingSpeculator* speculator )
         : IndexOperation( fileName, indexingData, interruptRequest, speculator ) { }
     virtual bool start();
@@ -120,7 +120,7 @@ class PartialIndexOperation : public IndexOperation
 {
   public:
     PartialIndexOperation( const QString& fileName, IndexingData* indexingData,
-			AtomicFlag* interruptRequest, EncodingSpeculator* speculator, qint64 position );
+            AtomicFlag* interruptRequest, EncodingSpeculator* speculator, qint64 position );
     virtual bool start();
 
   private:
@@ -179,8 +179,8 @@ class LogDataWorkerThread : public QThread
     QString fileName_;
 
     // Set when the thread must die
-	AtomicFlag terminate_;
-	AtomicFlag interruptRequested_;
+    AtomicFlag terminate_;
+    AtomicFlag interruptRequested_;
     IndexOperation* operationRequested_;
 
     // Pointer to the owner's indexing data (we modify it)

--- a/src/data/logfiltereddataworkerthread.h
+++ b/src/data/logfiltereddataworkerthread.h
@@ -87,7 +87,7 @@ class SearchOperation : public QObject
   Q_OBJECT
   public:
     SearchOperation( const LogData* sourceLogData,
-			const QRegExp& regExp, AtomicFlag* interruptRequest );
+            const QRegExp& regExp, AtomicFlag* interruptRequest );
 
     virtual ~SearchOperation() { }
 
@@ -105,7 +105,7 @@ class SearchOperation : public QObject
     // the shared results and the line to begin the search from.
     void doSearch( SearchData& result, qint64 initialLine );
 
-	AtomicFlag* interruptRequested_;
+    AtomicFlag* interruptRequested_;
     const QRegExp regexp_;
     const LogData* sourceLogData_;
 };
@@ -114,7 +114,7 @@ class FullSearchOperation : public SearchOperation
 {
   public:
     FullSearchOperation( const LogData* sourceLogData, const QRegExp& regExp,
-			AtomicFlag* interruptRequest )
+            AtomicFlag* interruptRequest )
         : SearchOperation( sourceLogData, regExp, interruptRequest ) {}
     virtual void start( SearchData& result );
 };
@@ -123,7 +123,7 @@ class UpdateSearchOperation : public SearchOperation
 {
   public:
     UpdateSearchOperation( const LogData* sourceLogData, const QRegExp& regExp,
-			AtomicFlag* interruptRequest, qint64 position )
+            AtomicFlag* interruptRequest, qint64 position )
         : SearchOperation( sourceLogData, regExp, interruptRequest ),
         initialPosition_( position ) {}
     virtual void start( SearchData& result );
@@ -177,8 +177,8 @@ class LogFilteredDataWorkerThread : public QThread
     QWaitCondition nothingToDoCond_;
 
     // Set when the thread must die
-	AtomicFlag terminate_;
-	AtomicFlag interruptRequested_;
+    AtomicFlag terminate_;
+    AtomicFlag interruptRequested_;
     SearchOperation* operationRequested_;
 
     // Shared indexing data

--- a/src/data/logfiltereddataworkerthread.h
+++ b/src/data/logfiltereddataworkerthread.h
@@ -26,6 +26,7 @@
 #include <QWaitCondition>
 #include <QRegExp>
 #include <QList>
+#include "atomicflag.h"
 
 class LogData;
 
@@ -86,7 +87,7 @@ class SearchOperation : public QObject
   Q_OBJECT
   public:
     SearchOperation( const LogData* sourceLogData,
-            const QRegExp& regExp, bool* interruptRequest );
+			const QRegExp& regExp, AtomicFlag* interruptRequest );
 
     virtual ~SearchOperation() { }
 
@@ -104,7 +105,7 @@ class SearchOperation : public QObject
     // the shared results and the line to begin the search from.
     void doSearch( SearchData& result, qint64 initialLine );
 
-    bool* interruptRequested_;
+	AtomicFlag* interruptRequested_;
     const QRegExp regexp_;
     const LogData* sourceLogData_;
 };
@@ -113,7 +114,7 @@ class FullSearchOperation : public SearchOperation
 {
   public:
     FullSearchOperation( const LogData* sourceLogData, const QRegExp& regExp,
-            bool* interruptRequest )
+			AtomicFlag* interruptRequest )
         : SearchOperation( sourceLogData, regExp, interruptRequest ) {}
     virtual void start( SearchData& result );
 };
@@ -122,7 +123,7 @@ class UpdateSearchOperation : public SearchOperation
 {
   public:
     UpdateSearchOperation( const LogData* sourceLogData, const QRegExp& regExp,
-            bool* interruptRequest, qint64 position )
+			AtomicFlag* interruptRequest, qint64 position )
         : SearchOperation( sourceLogData, regExp, interruptRequest ),
         initialPosition_( position ) {}
     virtual void start( SearchData& result );
@@ -176,8 +177,8 @@ class LogFilteredDataWorkerThread : public QThread
     QWaitCondition nothingToDoCond_;
 
     // Set when the thread must die
-    bool terminate_;
-    bool interruptRequested_;
+	AtomicFlag terminate_;
+	AtomicFlag interruptRequested_;
     SearchOperation* operationRequested_;
 
     // Shared indexing data


### PR DESCRIPTION
Setting bool is atomic in the sence that it can't be read while another thread is in the middle of writing a value. However, without proper memory fences compiler can reorder read and write operations in different threads. It's safer to use atomic operations explicitly.

QAtomicInt is available since Qt 4.4 that is pretty ancient. Created a wrapper class to make it easier to change implementation in future (use std::atomic_flag from C++11, or QAtomicInteger<quint8> from Qt 5.3).
