### PR TITLE
Moving using up/down keys - second try

### DIFF
--- a/src/abstractlogview.cpp
+++ b/src/abstractlogview.cpp
@@ -514,12 +514,28 @@ void AbstractLogView::timerEvent( QTimerEvent* timerEvent )
     QAbstractScrollArea::timerEvent( timerEvent );
 }
 
+void AbstractLogView::moveSelectionUp() {
+    int delta = qMin( -1, - digitsBuffer_.content() );
+    disableFollow();
+    moveSelection( delta );
+}
+
+void AbstractLogView::moveSelectionDown() {
+    int delta = qMax( 1, digitsBuffer_.content() );
+    disableFollow();
+    moveSelection( delta );
+}
+
 void AbstractLogView::keyPressEvent( QKeyEvent* keyEvent )
 {
     LOG(logDEBUG4) << "keyPressEvent received";
     bool controlModifier = (keyEvent->modifiers() & Qt::ControlModifier) == Qt::ControlModifier;
     bool shiftModifier = (keyEvent->modifiers() & Qt::ShiftModifier) == Qt::ShiftModifier;
 
+    if ( keyEvent->key() == Qt::Key_Up )
+	moveSelectionUp();
+    if ( keyEvent->key() == Qt::Key_Down )
+	moveSelectionDown();
     if ( keyEvent->key() == Qt::Key_Left )
         horizontalScrollBar()->triggerAction(QScrollBar::SliderPageStepSub);
     else if ( keyEvent->key() == Qt::Key_Right )
@@ -558,23 +574,11 @@ void AbstractLogView::keyPressEvent( QKeyEvent* keyEvent )
         else {
             switch ( (keyEvent->text())[0].toLatin1() ) {
                 case 'j':
-                    {
-                        int delta = qMax( 1, digitsBuffer_.content() );
-                        disableFollow();
-                        //verticalScrollBar()->triggerAction(
-                        //QScrollBar::SliderSingleStepAdd);
-                        moveSelection( delta );
-                        break;
-                    }
+                    moveSelectionDown();
+                    break;
                 case 'k':
-                    {
-                        int delta = qMin( -1, - digitsBuffer_.content() );
-                        disableFollow();
-                        //verticalScrollBar()->triggerAction(
-                        //QScrollBar::SliderSingleStepSub);
-                        moveSelection( delta );
-                        break;
-                    }
+                    moveSelectionUp();
+                    break;
                 case 'h':
                     horizontalScrollBar()->triggerAction(
                             QScrollBar::SliderSingleStepSub);

--- a/src/abstractlogview.h
+++ b/src/abstractlogview.h
@@ -382,6 +382,8 @@ class AbstractLogView :
     int convertCoordToColumn( int xPos ) const;
     void displayLine( LineNumber line );
     void moveSelection( int y );
+    void moveSelectionUp();
+    void moveSelectionDown();
     void jumpToStartOfLine();
     void jumpToEndOfLine();
     void jumpToRightOfScreen();


### PR DESCRIPTION
This change allows moving in AbstractLogView subclasses using key up and key down, keeping log file selection in sync with the search pane even when moving with the keyboard.


