### PR TITLE
Include required header for std::function

### DIFF
--- a/src/session.h
+++ b/src/session.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <vector>
 #include <utility>
+#include <functional>
 
 #include <QDateTime>
 #include <QByteArray>


### PR DESCRIPTION
This fixes a build failure with the upcoming GCC 7, because `<functional>` is no longer included implicitly by other headers.