### PR TITLE
Fix mouse button check

### DIFF
--- a/src/overviewwidget.cpp
+++ b/src/overviewwidget.cpp
@@ -229,7 +229,7 @@ void OverviewWidget::mousePressEvent( QMouseEvent* mouseEvent )
 
 void OverviewWidget::mouseMoveEvent( QMouseEvent* mouseEvent )
 {
-    if ( mouseEvent->buttons() |= Qt::LeftButton )
+    if ( mouseEvent->buttons().testFlag( Qt::LeftButton ) )
         handleMousePress( mouseEvent->y() );
 }
 


### PR DESCRIPTION
Hi,
Travis CI builds on Mac were failing with [error](https://travis-ci.org/variar/klogg/jobs/248460783):
```
src/overviewwidget.cpp:232:32: error: using the result of an assignment as a condition without parentheses [-Werror,-Wparentheses]
    if ( mouseEvent->buttons() |= Qt::LeftButton )
```

Was this assignment to passed QMouseEvent object intentional?