### PR TITLE
Fix selection copy

### DIFF
--- a/src/data/logdata.cpp
+++ b/src/data/logdata.cpp
@@ -380,7 +380,7 @@ QStringList LogData::doGetLines( qint64 first_line, int number ) const
     qint64 beginning = 0;
     qint64 end = 0;
     for ( qint64 line = first_line; (line <= last_line); line++ ) {
-        end = indexing_data_.getPosForLine( line ) + after_cr_offset_ - first_byte;
+        end = indexing_data_.getPosForLine( line ) - 1 + after_cr_offset_ - first_byte;
         // LOG(logDEBUG) << "Getting line " << line << " beginning " << beginning << " end " << end;
         QByteArray this_line = blob.mid( beginning, end - beginning );
         // LOG(logDEBUG) << "Line is: " << QString( this_line ).toStdString();


### PR DESCRIPTION
Since https://github.com/nickbnf/glogg/commit/2f6fa4628fc30ec8c0de04db338125ee1e7f7ae8, copying replaces the first character of all but the first line with a `\n`.

I'm not sure if this is right way to fix it, but it seems to work, and `getExpandedLines` also substracts 1 on line 334.