### PR TITLE
Keep selected line visible when search pattern changes

### DIFF
--- a/src/crawlerwidget.cpp
+++ b/src/crawlerwidget.cpp
@@ -328,6 +328,14 @@ void CrawlerWidget::updateFilteredView( int nbMatches, int progress )
         // Also update the top window for the coloured bullets.
         update();
     }
+
+    if ( progress == 100 ) {
+        const int currenLineIndex = logFilteredData_->getLineIndexNumber(currentLineNumber_);
+        LOG(logDEBUG) << "updateFilteredView: restoring selection: "
+                      << " absolute line number (0based) " << currentLineNumber_
+                      << " index " << currenLineIndex;
+        filteredView->selectAndDisplayLine(currenLineIndex);
+    }
 }
 
 void CrawlerWidget::jumpToMatchingLine(int filteredLineNb)
@@ -552,6 +560,9 @@ void CrawlerWidget::changeFilteredViewVisibility( int index )
         static_cast< FilteredView::Visibility>( item->data().toInt() );
 
     filteredView->setVisibility( visibility );
+
+    const int lineIndex = logFilteredData_->getLineIndexNumber( currentLineNumber_ );
+    filteredView->selectAndDisplayLine( lineIndex );
 }
 
 void CrawlerWidget::addToSearch( const QString& string )

--- a/src/data/logfiltereddata.cpp
+++ b/src/data/logfiltereddata.cpp
@@ -142,6 +142,11 @@ bool LogFilteredData::isLineInMatchingList( qint64 lineNumber )
             matching_lines_, lineNumber, &index);
 }
 
+int LogFilteredData::getLineIndexNumber( quint64 lineNumber ) const
+{
+    int lineIndex = findFilteredLine( lineNumber );
+    return lineIndex;
+}
 
 LineNumber LogFilteredData::getNbTotalLines() const
 {
@@ -312,6 +317,34 @@ LineNumber LogFilteredData::findLogDataLine( LineNumber lineNum ) const
     }
 
     return line;
+}
+
+LineNumber LogFilteredData::findFilteredLine( LineNumber lineNum ) const
+{
+    LineNumber lineIndex = std::numeric_limits<LineNumber>::max();
+
+    if ( visibility_ == MatchesOnly ) {
+        lineIndex = lookupLineNumber( matching_lines_.begin(),
+                                      matching_lines_.end(),
+                                      lineNum );
+    }
+    else if ( visibility_ == MarksOnly ) {
+        lineIndex = lookupLineNumber( marks_.begin(),
+                                      marks_.end(),
+                                      lineNum );
+    }
+    else {
+      // Regenerate the cache if needed
+        if ( filteredItemsCacheDirty_ ) {
+            regenerateFilteredItemsCache();
+        }
+
+        lineIndex = lookupLineNumber( filteredItemsCache_.begin(),
+                                      filteredItemsCache_.end(),
+                                      lineNum );
+    }
+
+    return lineIndex;
 }
 
 // Implementation of the virtual function.

--- a/src/data/logfiltereddata.h
+++ b/src/data/logfiltereddata.h
@@ -69,6 +69,10 @@ class LogFilteredData : public AbstractLogData {
     // Returns whether the line number passed is in our list of matching ones.
     bool isLineInMatchingList( qint64 lineNumber );
 
+    // Returns the line 'index' in filterd log data that matches
+    // given original line number
+    int getLineIndexNumber( quint64 lineNumber ) const;
+
     // Returns the number of lines in the source log data
     LineNumber getNbTotalLines() const;
     // Returns the number of matches (independently of the visibility)
@@ -153,6 +157,8 @@ class LogFilteredData : public AbstractLogData {
 
     // Utility functions
     LineNumber findLogDataLine( LineNumber lineNum ) const;
+    LineNumber findFilteredLine( LineNumber lineNum ) const;
+
     void regenerateFilteredItemsCache() const;
 };
 
@@ -174,6 +180,12 @@ class LogFilteredData::FilteredItem {
     { return lineNumber_; }
     FilteredLineType type() const
     { return type_; }
+
+    bool operator <( const LogFilteredData::FilteredItem& other ) const
+    { return lineNumber_ < other.lineNumber_; }
+
+    bool operator <( const LineNumber& lineNumber ) const
+    { return lineNumber_ < lineNumber; }
 
   private:
     LineNumber lineNumber_;

--- a/src/data/logfiltereddataworkerthread.h
+++ b/src/data/logfiltereddataworkerthread.h
@@ -41,6 +41,9 @@ class MatchingLine {
     // Accessors
     LineNumber lineNumber() const { return lineNumber_; }
 
+    bool operator <( const MatchingLine& other) const
+    { return lineNumber_ < other.lineNumber_; }
+
   private:
     LineNumber lineNumber_;
 };

--- a/src/marks.h
+++ b/src/marks.h
@@ -32,6 +32,9 @@ class Mark {
     // Accessors
     int lineNumber() const { return lineNumber_; }
 
+    bool operator <( const Mark& other ) const
+    { return lineNumber_ < other.lineNumber_; }
+
   private:
     int lineNumber_;
 };
@@ -67,7 +70,14 @@ class Marks {
 
     // Iterator
     // Provide a const_iterator for the client to iterate through the marks.
-    class const_iterator {
+    class const_iterator
+            : public std::iterator<
+                QList<Mark>::const_iterator::iterator_category,
+                QList<Mark>::const_iterator::value_type,
+                QList<Mark>::const_iterator::difference_type,
+                QList<Mark>::const_iterator::pointer,
+                QList<Mark>::const_iterator::reference>
+    {
       public:
         const_iterator( QList<Mark>::const_iterator iter )
         { internal_iter_ = iter; }
@@ -81,6 +91,20 @@ class Marks {
         { return ( internal_iter_ != other.internal_iter_ ); }
         const_iterator& operator++()
         { ++internal_iter_ ; return *this; }
+        const_iterator& operator--()
+        { --internal_iter_ ; return *this; }
+
+        int operator-( const const_iterator& other ) const
+        { return ( internal_iter_ - other.internal_iter_ ); }
+
+        const_iterator operator+(int n) const
+        { return const_iterator(internal_iter_ + n); }
+        const_iterator& operator+=(int n)
+        { internal_iter_+=n ; return *this; }
+        const_iterator operator-(int n) const
+        { return const_iterator(internal_iter_ - n); }
+        const_iterator& operator-=(int n)
+        { internal_iter_-=n ; return *this; }
 
       private:
         QList<Mark>::const_iterator internal_iter_;

--- a/src/utils.h
+++ b/src/utils.h
@@ -110,6 +110,20 @@ class FilePosition
     int column_;
 };
 
+template<typename Iterator>
+LineNumber lookupLineNumber( Iterator begin, Iterator end, LineNumber lineNum )
+{
+    LineNumber lineIndex = 0;
+    Iterator lowerBound = std::lower_bound( begin, end, lineNum );
+    if ( lowerBound != end ) {
+        lineIndex = std::distance(begin, lowerBound);
+    }
+    else if (begin != end) {
+        lineIndex = begin->lineNumber();
+    }
+    return lineIndex;
+}
+
 #ifndef HAVE_MAKE_UNIQUE
 #include <memory>
 


### PR DESCRIPTION
Prepared pull request for #61.
When filtering is finished try to select line in filtered view which is as close as possible to previous selection. I've been using this code almost every day since for about a year now, seems to be working, huge time saver.