### PR TITLE
Add more resources to windows executable

### DIFF
--- a/glogg.pro
+++ b/glogg.pro
@@ -133,7 +133,9 @@ macx {
 }
 else {
     # For Windows icon
-    RC_FILE = glogg.rc
+    RC_ICONS = glogg48.ico
+    QMAKE_TARGET_COMPANY = Nicolas Bonnefon
+    QMAKE_TARGET_DESCRIPTION = glogg - the fast, smart log explorer
 }
 
 RESOURCES = glogg.qrc

--- a/glogg.pro
+++ b/glogg.pro
@@ -134,8 +134,8 @@ macx {
 else {
     # For Windows icon
     RC_ICONS = glogg48.ico
-    QMAKE_TARGET_COMPANY = Nicolas Bonnefon
-    QMAKE_TARGET_DESCRIPTION = glogg - the fast, smart log explorer
+    QMAKE_TARGET_COMPANY = "Nicolas Bonnefon"
+    QMAKE_TARGET_DESCRIPTION = "glogg - the fast, smart log explorer"
 }
 
 RESOURCES = glogg.qrc

--- a/glogg.rc
+++ b/glogg.rc
@@ -1,1 +1,0 @@
-IDI_ICON1   ICON    DISCARDABLE     "glogg48.ico"


### PR DESCRIPTION
Modified pro-file to make qmake generate rc file with correct resources.  Should fix #182 It should also set file version automagically if VERSION is defined (like for release builds)