### PR TITLE
Save follow mode for opened files

### DIFF
--- a/src/crawlerwidget.cpp
+++ b/src/crawlerwidget.cpp
@@ -507,7 +507,7 @@ void CrawlerWidget::loadingFinishedHandler( LoadingStatus status )
 	}
     else {
         firstLoadDone_ = true;
-        for ( auto m : qAsConst( savedMarkedLines_ ) ) {
+        foreach ( LineNumber m, savedMarkedLines_ ) {
             logFilteredData_->addMark( m );
         }
     }
@@ -1198,8 +1198,8 @@ std::string CrawlerWidgetContext::toString() const
     QVariantMap properies;
 
     QVariantList sizes;
-    for ( const auto& item : qAsConst( sizes_ ) ) {
-        sizes.append( item );
+    foreach ( int size, sizes_ ) {
+        sizes.append( size );
     }
     properies["S"] = sizes;
 
@@ -1208,8 +1208,8 @@ std::string CrawlerWidgetContext::toString() const
     properies["FF"] = follow_file_;
 
     QVariantList marks;
-    for ( const auto& item : qAsConst( marks_ ) ) {
-        marks.append( item );
+    foreach ( LineNumber m, marks_ ) {
+        marks.append( m );
     }
     properies["M"] = marks;
 

--- a/src/crawlerwidget.h
+++ b/src/crawlerwidget.h
@@ -286,6 +286,9 @@ class CrawlerWidget : public QSplitter,
     // Is it not the first time we are loading something?
     bool            firstLoadDone_;
 
+    // Saved marked lines to be restored on first load
+    QList<LineNumber> savedMarkedLines_;
+
     // Current number of matches
     int             nbMatches_;
 

--- a/src/data/logfiltereddata.cpp
+++ b/src/data/logfiltereddata.cpp
@@ -268,6 +268,15 @@ void LogFilteredData::clearMarks()
     maxLengthMarks_ = 0;
 }
 
+QList<LineNumber> LogFilteredData::getMarks() const
+{
+    QList<LineNumber> markedLines;
+    for ( const auto& m : marks_ ) {
+        markedLines.append( m.lineNumber() );
+    }
+    return markedLines;
+}
+
 void LogFilteredData::setVisibility( Visibility visi )
 {
     visibility_ = visi;

--- a/src/data/logfiltereddata.h
+++ b/src/data/logfiltereddata.h
@@ -105,6 +105,8 @@ class LogFilteredData : public AbstractLogData {
     void deleteMark( qint64 line );
     // Completely clear the marks list.
     void clearMarks();
+    // Get all marked lines
+    QList<LineNumber> getMarks() const;
 
     // Changes what the AbstractLogData returns via its getXLines/getNbLines
     // API.

--- a/src/marks.h
+++ b/src/marks.h
@@ -106,6 +106,11 @@ class Marks {
         const_iterator& operator-=(int n)
         { internal_iter_-=n ; return *this; }
 
+        bool operator<(const const_iterator& other) const
+        {
+            return internal_iter_ < other.internal_iter_;
+        }
+
       private:
         QList<Mark>::const_iterator internal_iter_;
     };


### PR DESCRIPTION
It address issue  #183. Stores follow mode in widget context string and reapply when file is reopened.