### PR TITLE
FiltersDialog now uses a color picker for color selection

### DIFF
--- a/src/filtersdialog.h
+++ b/src/filtersdialog.h
@@ -44,22 +44,29 @@ class FiltersDialog : public QDialog, public Ui::FiltersDialog
     void on_buttonBox_clicked( QAbstractButton* button );
     void on_upFilterButton_clicked();
     void on_downFilterButton_clicked();
+    void on_ignoreCaseCheckBox_clicked();
+    void on_patternEdit_editingFinished();
+    void on_foreColorButton_clicked();
+    void on_backColorButton_clicked();
     // Update the property (pattern, color...) fields from the
     // selected Filter.
     void updatePropertyFields();
-    // Update the selected Filter from the values in the property fields.
-    void updateFilterProperties();
+
 
   private:
+    static bool showColorPicker(const QColor& in , QColor& out);
+    void updateIcon(QPushButton* button , QColor color);
     // Temporary filterset modified by the dialog
     // it is copied from the one in Config()
     std::shared_ptr<FilterSet> filterSet;
+    QColor foreColor , backColor;
 
     // Index of the row currently selected or -1 if none.
     int selectedRow_;
 
     void populateColors();
     void populateFilterList();
+
 };
 
 #endif

--- a/src/filtersdialog.ui
+++ b/src/filtersdialog.ui
@@ -122,34 +122,6 @@
              </property>
             </widget>
            </item>
-           <item row="4" column="0">
-            <widget class="QLabel" name="label_2">
-             <property name="text">
-              <string>Fore Color: </string>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="1">
-            <widget class="QComboBox" name="backColorBox">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="1">
-            <widget class="QComboBox" name="foreColorBox">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="0">
-            <widget class="QLabel" name="label_3">
-             <property name="text">
-              <string>Back Color: </string>
-             </property>
-            </widget>
-           </item>
            <item row="3" column="0">
             <widget class="QCheckBox" name="ignoreCaseCheckBox">
              <property name="enabled">
@@ -161,6 +133,78 @@
              <property name="checked">
               <bool>false</bool>
              </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="label_2">
+             <property name="text">
+              <string>Fore Color: </string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QFrame" name="frame">
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="frameShadow">
+              <enum>QFrame::Raised</enum>
+             </property>
+             <widget class="QPushButton" name="foreColorButton">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>60</width>
+                <height>18</height>
+               </rect>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="iconSize">
+               <size>
+                <width>40</width>
+                <height>10</height>
+               </size>
+              </property>
+             </widget>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="label_3">
+             <property name="text">
+              <string>Back Color: </string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="1">
+            <widget class="QFrame" name="frame_2">
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="frameShadow">
+              <enum>QFrame::Raised</enum>
+             </property>
+             <widget class="QPushButton" name="backColorButton">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>60</width>
+                <height>18</height>
+               </rect>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
             </widget>
            </item>
           </layout>

--- a/src/filterset.h
+++ b/src/filterset.h
@@ -34,7 +34,7 @@ class Filter
     // Construct an uninitialized Filter (when reading from a config file)
     Filter();
     Filter(const QString& pattern, bool ignoreCase,
-            const QString& foreColor, const QString& backColor );
+            const QColor& foreColor, const QColor& backColor );
 
     bool hasMatch( const QString& string ) const;
 
@@ -43,10 +43,10 @@ class Filter
     void setPattern( const QString& pattern );
     bool ignoreCase() const;
     void setIgnoreCase( bool ignoreCase );
-    const QString& foreColorName() const;
-    void setForeColor( const QString& foreColorName );
-    const QString& backColorName() const;
-    void setBackColor( const QString& backColorName );
+    const QColor& foreColor() const;
+    void setForeColor( const QColor& foreColor );
+    const QColor& backColor() const;
+    void setBackColor( const QColor& backColor );
 
     // Operators for serialization
     // (must be kept to migrate filters from <=0.8.2)
@@ -59,8 +59,8 @@ class Filter
 
   private:
     QRegularExpression regexp_;
-    QString foreColorName_;
-    QString backColorName_;
+    QColor foreColor_;
+    QColor backColor_;
     bool enabled_;
 };
 


### PR DESCRIPTION
-FiltersDialog no longer uses a drop down box of predefined SVG color strings. In place it uses two push buttons that launch a QColorDialog. This allows for custom color specification.

-refactored Filter class to use QColor for its fore and back colors, instead of the old approach which uses strings. This reduces coupling with UI.

-incrememnted FilterSet::FILTERSET_VERSION to 2, since Filters now store custom colors. These colors are saved in config as hex strings. BACKWARDS COMPATIBILITY IS MAINTAINED WITH VERSION 1 CONFIG FILES. (made the assumption that backwards compatibility should always be maintained.)