### PR TITLE
Switch to 10.8 to use recent Qt on mac

### DIFF
--- a/glogg.pro
+++ b/glogg.pro
@@ -228,7 +228,7 @@ macx {
     QMAKE_CXXFLAGS += -stdlib=libc++
     QMAKE_LFLAGS += -stdlib=libc++
 
-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7
+    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.8
 
     QMAKE_INFO_PLIST = Info.plist
 }


### PR DESCRIPTION
CI builds failed on Mac because Qt 5.10 gets installed with brew.

This mac ci issue has two possible fixes. Either setting QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.8 and building with Qt 5.10 or changing ci script to get Qt 5.6 from brew and thus end up using the same Qt version for all ci builds.  I was unable to pin exact Qt version on mac, so dropping 10.7 support might be the easiest solution.

p.s.
In my opinion Qt 5.9 should be used on all ci builds as it is current LTS version.