### PR TITLE
Project file fixes

### DIFF
--- a/glogg.pro
+++ b/glogg.pro
@@ -192,20 +192,11 @@ UI_DIR = $${OUT_PWD}/.ui/$${DESTDIR}-shared
 # Debug symbols even in release build
 QMAKE_CXXFLAGS = -g
 
-# Which compiler are we using
-system( $${QMAKE_CXX} --version | grep -e " 4\\.[7-9]" ) || macx {
-    message ( "g++ version 4.7 or newer, supports C++11" )
-    CONFIG += C++11
-}
-else {
-    CONFIG += C++0x
-}
+CONFIG += c++11
 
 # Extra compiler arguments
 # QMAKE_CXXFLAGS += -Weffc++
 QMAKE_CXXFLAGS += -Wextra
-C++0x:QMAKE_CXXFLAGS += -std=c++0x
-C++11:QMAKE_CXXFLAGS += -std=c++11
 
 GPROF {
     QMAKE_CXXFLAGS += -pg

--- a/glogg.pro
+++ b/glogg.pro
@@ -240,7 +240,7 @@ else {
 }
 
 # Optional features (e.g. CONFIG+=no-dbus)
-system(pkg-config --exists QtDBus):!no-dbus {
+system(pkg-config --exists Qt5DBus):!no-dbus {
     message("Support for D-BUS will be included")
     QT += dbus
     QMAKE_CXXFLAGS += -DGLOGG_SUPPORTS_DBUS


### PR DESCRIPTION
On Ubuntu 16.04.4 at least, the pkgconfig-check for "QtDBus" fails and needs to be "Qt5DBus" instead.
I don't know if this is something distribution-specific or something, so you'll definitely want to make sure D-Bus support is still compiled in with this change on your systems.