### PR TITLE
Fix "Index too big"-messages when toggling filtered-view modes

### DIFF
--- a/src/crawlerwidget.cpp
+++ b/src/crawlerwidget.cpp
@@ -572,8 +572,10 @@ void CrawlerWidget::changeFilteredViewVisibility( int index )
 
     filteredView->setVisibility( visibility );
 
-    const int lineIndex = logFilteredData_->getLineIndexNumber( currentLineNumber_ );
-    filteredView->selectAndDisplayLine( lineIndex );
+    if ( logFilteredData_->getNbLine() > 0 ) {
+        const int lineIndex = logFilteredData_->getLineIndexNumber( currentLineNumber_ );
+        filteredView->selectAndDisplayLine( lineIndex );
+    }
 }
 
 void CrawlerWidget::addToSearch( const QString& string )

--- a/src/utils.h
+++ b/src/utils.h
@@ -118,9 +118,6 @@ LineNumber lookupLineNumber( Iterator begin, Iterator end, LineNumber lineNum )
     if ( lowerBound != end ) {
         lineIndex = std::distance(begin, lowerBound);
     }
-    else if (begin != end) {
-        lineIndex = begin->lineNumber();
-    }
     return lineIndex;
 }
 


### PR DESCRIPTION
I got "Index too big in LogFilteredData" warnings when switching between the filtered-view modes (marks/matches).
These changes should prevent the situation from occurring.