### PR TITLE
Fix Clang warnings

### DIFF
--- a/src/inotifywatchtowerdriver.h
+++ b/src/inotifywatchtowerdriver.h
@@ -25,7 +25,7 @@
 #include <vector>
 
 template <typename Driver>
-class ObservedFile;
+struct ObservedFile;
 template <typename Driver>
 class ObservedFileList;
 

--- a/src/watchtower.h
+++ b/src/watchtower.h
@@ -104,10 +104,7 @@ class WatchTower {
 
 #include "log.h"
 
-namespace {
-    bool isSymLink( const std::string& file_name );
-    std::string directory_path( const std::string& path );
-};
+inline bool isSymLink( const std::string& file_name );
 
 template <typename Driver>
 WatchTower<Driver>::WatchTower()
@@ -318,18 +315,16 @@ void WatchTower<Driver>::run()
     }
 }
 
-namespace {
-    bool isSymLink( const std::string& file_name )
-    {
+bool isSymLink( const std::string& file_name )
+{
 #ifdef HAVE_SYMLINK
-        struct stat buf;
+    struct stat buf;
 
-        lstat( file_name.c_str(), &buf );
-        return ( S_ISLNK(buf.st_mode) );
+    lstat( file_name.c_str(), &buf );
+    return ( S_ISLNK(buf.st_mode) );
 #else
-        return false;
+    return false;
 #endif
-    }
-};
+}
 
 #endif

--- a/src/watchtowerlist.h
+++ b/src/watchtowerlist.h
@@ -204,9 +204,7 @@ class ObservedFileList {
         void cleanRefsToExpiredDirs();
 };
 
-namespace {
-    std::string directory_path( const std::string& path );
-};
+inline std::string directory_path( const std::string& path );
 
 // ObservedFileList class
 template <typename Driver>
@@ -408,21 +406,19 @@ void ObservedFileList<Driver>::cleanRefsToExpiredDirs()
     }
 }
 
-namespace {
-    std::string directory_path( const std::string& path )
-    {
-        size_t slash_pos = path.rfind( '/' );
+std::string directory_path( const std::string& path )
+{
+    size_t slash_pos = path.rfind( '/' );
 
 #ifdef _WIN32
-        if ( slash_pos == std::string::npos ) {
-            slash_pos = path.rfind( '\\' );
-        }
+    if ( slash_pos == std::string::npos ) {
+        slash_pos = path.rfind( '\\' );
+    }
 
-        // We need to include the final slash on Windows
-        ++slash_pos;
+    // We need to include the final slash on Windows
+    ++slash_pos;
 #endif
 
-        return std::string( path, 0, slash_pos );
-    }
-};
+    return std::string( path, 0, slash_pos );
+}
 #endif


### PR DESCRIPTION
The reason for replacement of `class ObservedFile` to `struct ObservedFile` should be rather obvious.

Using `inline` in favor of an anonymous namespace is because the latter generates warnings about unused functions if the header is included in files which do not use them.
It is possible to do both, i.e. define the functions as `inline` in an anonymous namespace, though I guess the anonymous namespace was used to prevent linking-issues ("One Definition Rule") and not specifically because each TU should get it's own copy. `inline` functions are exempt from the ODR.